### PR TITLE
Force thunk nodes so that they can be JSON.stringified

### DIFF
--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -1,7 +1,51 @@
 var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
+    function forceThunks(vNode) {
+        switch (vNode.type)
+        {
+            case 'thunk':
+                if (!vNode.node) {
+                    vNode.node = vNode.thunk();
+                    forceThunks(vNode.node);
+                }
+                return;
+
+            case 'tagger':
+                forceThunks(vNode.node);
+                return;
+
+            case 'text':
+                return;
+
+            case 'node':
+                var children = vNode.children;
+
+                for (var i = 0; i < children.length; i++) {
+                    forceThunks(children[i]);
+                }
+
+                return;
+
+            case 'keyed-node':
+                var children = vNode.children;
+
+                for (var i = 0; i < children.length; i++) {
+                    forceThunks(children[i]);
+                }
+
+                return domNode;
+
+            case 'custom':
+                return;
+
+            default:
+                throw new Error('Unknown virtual-dom node type: ' + vNode.type);
+        }
+    }
+
     // stringify needed to strip functions - can performance-optimize this later!
     return {
         toJsonString: function(html) {
+            forceThunks(html);
             var asString = JSON.stringify(html);
 
             if (typeof asString === "undefined"){


### PR DESCRIPTION
This forces all the thunks (created with `Html.Lazy`) so that later `elm-html-in-elm` can parse the forced `node` values out of the stringified JSON.  This follows the pattern used in the real rendering code: https://github.com/elm-lang/virtual-dom/blob/master/src/Native/VirtualDom.js#L293-L359

This, along with https://github.com/eeue56/elm-html-in-elm/pull/2, is a possible solution to #4.