### PR TITLE
Handle thunks

### DIFF
--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -1,7 +1,51 @@
 var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
+    function forceThunks(vNode) {
+        switch (vNode.type)
+        {
+            case 'thunk':
+                if (!vNode.node) {
+                    vNode.node = vNode.thunk();
+                    forceThunks(vNode.node);
+                }
+                return;
+
+            case 'tagger':
+                forceThunks(vNode.node);
+                return;
+
+            case 'text':
+                return;
+
+            case 'node':
+                var children = vNode.children;
+
+                for (var i = 0; i < children.length; i++) {
+                    forceThunks(children[i]);
+                }
+
+                return;
+
+            case 'keyed-node':
+                var children = vNode.children;
+
+                for (var i = 0; i < children.length; i++) {
+                    forceThunks(children[i]);
+                }
+
+                return domNode;
+
+            case 'custom':
+                return;
+
+            default:
+                throw new Error('Unknown virtual-dom node type: ' + vNode.type);
+        }
+    }
+
     // stringify needed to strip functions - can performance-optimize this later!
     return {
         toJsonString: function(html) {
+            forceThunks(html);
             var asString = JSON.stringify(html);
 
             if (typeof asString === "undefined"){

--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -1,52 +1,17 @@
 var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
-    function forceThunks(vNode) {
-        switch (vNode.type)
-        {
-            case 'thunk':
-                if (!vNode.node) {
-                    vNode.node = vNode.thunk();
-                    forceThunks(vNode.node);
-                }
-                return;
-
-            case 'tagger':
-                forceThunks(vNode.node);
-                return;
-
-            case 'text':
-                return;
-
-            case 'node':
-                var children = vNode.children;
-
-                for (var i = 0; i < children.length; i++) {
-                    forceThunks(children[i]);
-                }
-
-                return;
-
-            case 'keyed-node':
-                var children = vNode.children;
-
-                for (var i = 0; i < children.length; i++) {
-                    forceThunks(children[i]);
-                }
-
-                return domNode;
-
-            case 'custom':
-                return;
-
-            default:
-                throw new Error('Unknown virtual-dom node type: ' + vNode.type);
+    function forceThunks(key, vNode) {
+        if (typeof vNode !== 'undefined' && vNode.type === 'thunk' && !vNode.node) {
+            vNode.node = vNode.thunk.apply(vNode.thunk, vNode.args);
+            return vNode;
+        } else {
+            return vNode;
         }
     }
 
     // stringify needed to strip functions - can performance-optimize this later!
     return {
         toJsonString: function(html) {
-            forceThunks(html);
-            var asString = JSON.stringify(html);
+            var asString = JSON.stringify(html, forceThunks);
 
             if (typeof asString === "undefined"){
                 return "";

--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -1,17 +1,18 @@
 var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
-    function forceThunks(key, vNode) {
+    function forceThunks(vNode) {
         if (typeof vNode !== 'undefined' && vNode.type === 'thunk' && !vNode.node) {
             vNode.node = vNode.thunk.apply(vNode.thunk, vNode.args);
-            return vNode;
-        } else {
-            return vNode;
         }
+        if (typeof vNode !== 'undefined' && typeof vNode.children !== 'undefined') {
+            vNode.children = vNode.children.map(forceThunks);
+        }
+        return vNode;
     }
 
     // stringify needed to strip functions - can performance-optimize this later!
     return {
         toJsonString: function(html) {
-            var asString = JSON.stringify(html, forceThunks);
+            var asString = JSON.stringify(forceThunks(html));
 
             if (typeof asString === "undefined"){
                 return "";


### PR DESCRIPTION
> This forces all the thunks (created with Html.Lazy) so that later elm-html-in-elm can parse the forced node values out of the stringified JSON. This follows the pattern used in the real rendering code: https://github.com/elm-lang/virtual-dom/blob/master/src/Native/VirtualDom.js#L293-L359

This, along with eeue56/elm-html-in-elm#2, is a possible solution to #4.


This adds tests to @avh4's PR (commit by av is included)


💭 I wonder if we should call `.thunk` with it's arguments. It works without that change though.
`                    vNode.node = vNode.thunk.apply(vNode.thunk, vNode.args);`


**This replaces #5**