### PR TITLE
add Query.hasNot

### DIFF
--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -10,6 +10,7 @@ module Test.Html.Query
         , index
         , count
         , has
+        , hasNot
         , each
         )
 
@@ -23,7 +24,7 @@ module Test.Html.Query
 
 ## Expecting
 
-@docs count, has, each
+@docs count, has, hasNot, each
 -}
 
 import Html exposing (Html)
@@ -312,6 +313,27 @@ has : List Selector -> Single -> Expectation
 has selectors (Internal.Single showTrace query) =
     Internal.has selectors query
         |> failWithQuery showTrace ("Query.has " ++ Internal.joinAsList selectorToString selectors) query
+
+
+{-| Expect the element to **not** match all of the given selectors.
+
+    import Html exposing (div, ul, li)
+    import Test.Html.Query as Query
+    import Test exposing (test)
+    import Test.Html.Selector exposing (tag, class)
+
+
+    test "The div element has no progress-bar class" <|
+        \() ->
+            div  []
+                |> Query.fromHtml
+                |> Query.find [ tag "div" ]
+                |> Query.hasNot [ tag "div", class "progress-bar" ]
+-}
+hasNot : List Selector -> Single -> Expectation
+hasNot selectors (Internal.Single showTrace query) =
+    Internal.hasNot selectors query
+        |> failWithQuery showTrace ("Query.hasNot " ++ Internal.joinAsList selectorToString selectors) query
 
 
 {-| Expect that a [`Single`](#Single) expectation will hold true for each of the

--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -317,7 +317,8 @@ has selectors (Internal.Single showTrace query) =
 
 {-| Expect the element to **not** match all of the given selectors.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div)
+    import Html.Attributes as Attributes
     import Test.Html.Query as Query
     import Test exposing (test)
     import Test.Html.Selector exposing (tag, class)
@@ -325,15 +326,19 @@ has selectors (Internal.Single showTrace query) =
 
     test "The div element has no progress-bar class" <|
         \() ->
-            div  []
+            div [ Attributes.class "button" ] []
                 |> Query.fromHtml
                 |> Query.find [ tag "div" ]
                 |> Query.hasNot [ tag "div", class "progress-bar" ]
 -}
 hasNot : List Selector -> Single -> Expectation
 hasNot selectors (Internal.Single showTrace query) =
-    Internal.hasNot selectors query
-        |> failWithQuery showTrace ("Query.hasNot " ++ Internal.joinAsList selectorToString selectors) query
+    let
+        queryName =
+            "Query.hasNot " ++ Internal.joinAsList selectorToString selectors
+    in
+        Internal.hasNot selectors query
+            |> failWithQuery showTrace queryName query
 
 
 {-| Expect that a [`Single`](#Single) expectation will hold true for each of the

--- a/src/Test/Html/Query/Internal.elm
+++ b/src/Test/Html/Query/Internal.elm
@@ -427,7 +427,7 @@ hasNot selectors query =
                 Expect.pass
             else
                 selectors
-                    |> List.map (showSelectorOutcome elmHtmlList)
+                    |> List.map (showSelectorOutcomeInverse elmHtmlList)
                     |> String.join "\n"
                     |> Expect.fail
 
@@ -445,3 +445,15 @@ showSelectorOutcome elmHtmlList selector =
                 "✓"
     in
         String.join " " [ outcome, "has", selectorToString selector ]
+
+
+showSelectorOutcomeInverse : List ElmHtml -> Selector -> String
+showSelectorOutcomeInverse elmHtmlList selector =
+    let
+        outcome =
+            if List.isEmpty (InternalSelector.queryAll [ selector ] elmHtmlList) then
+                "✓"
+            else
+                "✗"
+    in
+        String.join " " [ outcome, "has not", selectorToString selector ]

--- a/src/Test/Html/Query/Internal.elm
+++ b/src/Test/Html/Query/Internal.elm
@@ -419,6 +419,22 @@ has selectors query =
             Expect.fail (queryErrorToString query error)
 
 
+hasNot : List Selector -> Query -> Expectation
+hasNot selectors query =
+    case traverse query of
+        Ok elmHtmlList ->
+            if List.isEmpty (InternalSelector.queryAll selectors elmHtmlList) then
+                Expect.pass
+            else
+                selectors
+                    |> List.map (showSelectorOutcome elmHtmlList)
+                    |> String.join "\n"
+                    |> Expect.fail
+
+        Err error ->
+            Expect.pass
+
+
 showSelectorOutcome : List ElmHtml -> Selector -> String
 showSelectorOutcome elmHtmlList selector =
     let

--- a/src/Test/Html/Query/Internal.elm
+++ b/src/Test/Html/Query/Internal.elm
@@ -422,14 +422,19 @@ has selectors query =
 hasNot : List Selector -> Query -> Expectation
 hasNot selectors query =
     case traverse query of
+        Ok [] ->
+            Expect.pass
+
         Ok elmHtmlList ->
-            if List.isEmpty (InternalSelector.queryAll selectors elmHtmlList) then
-                Expect.pass
-            else
-                selectors
-                    |> List.map (showSelectorOutcomeInverse elmHtmlList)
-                    |> String.join "\n"
-                    |> Expect.fail
+            case InternalSelector.queryAll selectors elmHtmlList of
+                [] ->
+                    Expect.pass
+
+                _ ->
+                    selectors
+                        |> List.map (showSelectorOutcomeInverse elmHtmlList)
+                        |> String.join "\n"
+                        |> Expect.fail
 
         Err error ->
             Expect.pass
@@ -439,10 +444,12 @@ showSelectorOutcome : List ElmHtml -> Selector -> String
 showSelectorOutcome elmHtmlList selector =
     let
         outcome =
-            if List.isEmpty (InternalSelector.queryAll [ selector ] elmHtmlList) then
-                "✗"
-            else
-                "✓"
+            case InternalSelector.queryAll [ selector ] elmHtmlList of
+                [] ->
+                    "✗"
+
+                _ ->
+                    "✓"
     in
         String.join " " [ outcome, "has", selectorToString selector ]
 
@@ -451,9 +458,11 @@ showSelectorOutcomeInverse : List ElmHtml -> Selector -> String
 showSelectorOutcomeInverse elmHtmlList selector =
     let
         outcome =
-            if List.isEmpty (InternalSelector.queryAll [ selector ] elmHtmlList) then
-                "✓"
-            else
-                "✗"
+            case InternalSelector.queryAll [ selector ] elmHtmlList of
+                [] ->
+                    "✓"
+
+                _ ->
+                    "✗"
     in
         String.join " " [ outcome, "has not", selectorToString selector ]


### PR DESCRIPTION
The inverse of `Query.has` that checks for the absence of an element
that satisfies all selectors. Implemented as discussed in #8 

I've also inverted the error reporting for hasNot, to look like 

```
↓ The option values for Progress
✗ expect no custom label

    ▼ Query.fromHtml

        <div class="progress">
            <div class="progress-bar">
                <div class="custom-label">
                </div>
            </div>
        </div>

    ▼ Query.hasNot [ tag "div", class "custom-label" ]

    ✗ has not tag "div"
    ✗ has not class "custom-label"
```



