### PR TITLE
Tests that break current implementation of Query.children

### DIFF
--- a/tests/Queries.elm
+++ b/tests/Queries.elm
@@ -167,23 +167,28 @@ testIndex output =
 testChildren : Single -> Test
 testChildren output =
     describe "Query.children"
-        [ describe "on the root" <|
-            [ test "sees the root has one child" <|
-                \() ->
+        [ describe "on .container" <|
+            let
+                container =
                     output
-                        |> Query.children []
-                        |> Query.count (Expect.equal 1)
-            , test "sees it's a <header id='heading'>" <|
-                \() ->
-                    output
-                        |> Query.children []
-                        |> Query.each (Query.has [ tag "header", id "heading" ])
-            , test "doesn't see the nested div" <|
-                \() ->
-                    output
-                        |> Query.children [ tag "div" ]
-                        |> Query.count (Expect.equal 1)
-            ]
+                        |> Query.find [ class "container" ]
+            in
+                [ test "returns all the children" <|
+                    \() ->
+                        container
+                            |> Query.children []
+                            |> Query.count (Expect.equal 4)
+                , test "returns a selected child" <|
+                    \() ->
+                        container
+                            |> Query.children [ class "funky" ]
+                            |> Query.count (Expect.equal 2)
+                , test "doesn't see the nested div" <|
+                    \() ->
+                        container
+                            |> Query.children [ tag "div" ]
+                            |> Query.count (Expect.equal 0)
+                ]
         ]
 
 


### PR DESCRIPTION
This branch now contains a test for `Query.children` to show why it does not currently work. A proposed fix will be introduced in a future branch.

Paired with @rtfeldman 