### PR TITLE
Do not merge - bad children fix

### DIFF
--- a/src/Test/Html/Query/Internal.elm
+++ b/src/Test/Html/Query/Internal.elm
@@ -3,6 +3,7 @@ module Test.Html.Query.Internal exposing (..)
 import Test.Html.Selector.Internal as InternalSelector exposing (Selector, selectorToString)
 import Html.Inert as Inert exposing (Node)
 import ElmHtml.InternalTypes exposing (ElmHtml(..))
+import ElmHtml.Query
 import ElmHtml.ToString exposing (nodeToStringWithOptions)
 import Expect exposing (Expectation)
 
@@ -114,7 +115,7 @@ toLinesHelp expectationFailure elmHtmlList selectorQueries queryName results =
                         let
                             elements =
                                 elmHtmlList
-                                    |> InternalSelector.queryAllChildren selectors
+                                    |> InternalSelector.queryOnlyChildren selectors
                         in
                             ("Query.children " ++ joinAsList selectorToString selectors)
                                 |> withHtmlContext (getHtmlContext elements)
@@ -284,7 +285,7 @@ traverseSelector selectorQuery elmHtmlList =
 
         Children selectors ->
             elmHtmlList
-                |> InternalSelector.queryAllChildren selectors
+                |> InternalSelector.queryOnlyChildren selectors
                 |> Ok
 
         First ->

--- a/src/Test/Html/Selector/Internal.elm
+++ b/src/Test/Html/Selector/Internal.elm
@@ -1,7 +1,8 @@
 module Test.Html.Selector.Internal exposing (..)
 
-import ElmHtml.InternalTypes exposing (ElmHtml)
-import ElmHtml.Query
+import Dict
+import ElmHtml.InternalTypes exposing (..)
+import ElmHtml.Query exposing (Selector(..))
 
 
 type Selector
@@ -52,23 +53,152 @@ queryAll selectors list =
                 |> queryAll rest
 
 
+getChildren : ElmHtml -> List ElmHtml
+getChildren node =
+    case node of
+        NodeEntry { children } ->
+            children
+
+        _ ->
+            []
+
+
 queryOnlyChildren : List Selector -> List ElmHtml -> List ElmHtml
 queryOnlyChildren selectors list =
-    let
-        querySelectors =
-            List.map toQuerySelector selectors
+    applySelectors selectors (List.concatMap getChildren list)
 
-        parentNode =
-            List.head list
 
-        dropParentIfIncluded elements =
-            if List.head elements == parentNode then
-                List.drop 1 elements
-            else
-                elements
-    in
-        List.concatMap (ElmHtml.Query.queryChildrenAll querySelectors) list
-            |> dropParentIfIncluded
+applySelectors : List Selector -> List ElmHtml -> List ElmHtml
+applySelectors selectors elements =
+    case selectors of
+        [] ->
+            elements
+
+        selector :: rest ->
+            List.filter (trySelector selector) elements
+                |> applySelectors rest
+
+
+trySelector : Selector -> ElmHtml -> Bool
+trySelector selector node =
+    predicateFromSelector (toQuerySelector selector) node
+
+
+predicateFromSelector : ElmHtml.Query.Selector -> ElmHtml -> Bool
+predicateFromSelector selector html =
+    case html of
+        NodeEntry record ->
+            record
+                |> nodeRecordPredicate selector
+
+        _ ->
+            False
+
+
+hasAttribute : String -> String -> Facts -> Bool
+hasAttribute attribute query facts =
+    case Dict.get attribute facts.stringAttributes of
+        Just id ->
+            id == query
+
+        Nothing ->
+            False
+
+
+hasBoolAttribute : String -> Bool -> Facts -> Bool
+hasBoolAttribute attribute value facts =
+    case Dict.get attribute facts.boolAttributes of
+        Just id ->
+            id == value
+
+        Nothing ->
+            False
+
+
+classnames : Facts -> List String
+classnames facts =
+    Dict.get "className" facts.stringAttributes
+        |> Maybe.withDefault ""
+        |> String.split " "
+
+
+hasClass : String -> Facts -> Bool
+hasClass query facts =
+    List.member query (classnames facts)
+
+
+hasClasses : List String -> Facts -> Bool
+hasClasses classList facts =
+    containsAll classList (classnames facts)
+
+
+containsAll : List a -> List a -> Bool
+containsAll a b =
+    b
+        |> List.foldl (\i acc -> List.filter ((/=) i) acc) a
+        |> List.isEmpty
+
+
+hasAllSelectors : List ElmHtml.Query.Selector -> ElmHtml -> Bool
+hasAllSelectors selectors record =
+    List.map predicateFromSelector selectors
+        |> List.map (\selector -> selector record)
+        |> List.all identity
+
+
+nodeRecordPredicate : ElmHtml.Query.Selector -> (NodeRecord -> Bool)
+nodeRecordPredicate selector =
+    case selector of
+        Id id ->
+            .facts
+                >> hasAttribute "id" id
+
+        ClassName classname ->
+            .facts
+                >> hasClass classname
+
+        ClassList classList ->
+            .facts
+                >> hasClasses classList
+
+        ElmHtml.Query.Tag tag ->
+            .tag
+                >> (==) tag
+
+        ElmHtml.Query.Attribute key value ->
+            .facts
+                >> hasAttribute key value
+
+        ElmHtml.Query.BoolAttribute key value ->
+            .facts
+                >> hasBoolAttribute key value
+
+        ContainsText text ->
+            always False
+
+        Multiple selectors ->
+            NodeEntry
+                >> hasAllSelectors selectors
+
+
+
+-- queryOnlyChildren : List Selector -> List ElmHtml -> List ElmHtml
+-- queryOnlyChildren selectors list =
+--     let
+--         querySelectors =
+--             List.map toQuerySelector selectors
+--
+--         parentNode =
+--             List.head list
+--
+--         dropParentIfIncluded elements =
+--             if List.head elements == parentNode then
+--                 List.drop 1 elements
+--             else
+--                 elements
+--     in
+--         List.concatMap (ElmHtml.Query.queryChildrenAll querySelectors) list
+--             |> dropParentIfIncluded
 
 
 toQuerySelector : Selector -> ElmHtml.Query.Selector

--- a/tests/Queries.elm
+++ b/tests/Queries.elm
@@ -167,23 +167,28 @@ testIndex output =
 testChildren : Single -> Test
 testChildren output =
     describe "Query.children"
-        [ describe "on the root" <|
-            [ test "sees the root has one child" <|
-                \() ->
+        [ describe "on .container" <|
+            let
+                container =
                     output
-                        |> Query.children []
-                        |> Query.count (Expect.equal 1)
-            , test "sees it's a <header id='heading'>" <|
-                \() ->
-                    output
-                        |> Query.children []
-                        |> Query.each (Query.has [ tag "header", id "heading" ])
-            , test "doesn't see the nested div" <|
-                \() ->
-                    output
-                        |> Query.children [ tag "div" ]
-                        |> Query.count (Expect.equal 1)
-            ]
+                        |> Query.find [ class "container" ]
+            in
+                [ test "returns all the children" <|
+                    \() ->
+                        container
+                            |> Query.children []
+                            |> Query.count (Expect.equal 4)
+                , test "returns a selected child" <|
+                    \() ->
+                        container
+                            |> Query.children [ class "funky" ]
+                            |> Query.count (Expect.equal 2)
+                , test "doesn't see the nested div" <|
+                    \() ->
+                        container
+                            |> Query.children [ tag "div" ]
+                            |> Query.count (Expect.equal 0)
+                ]
         ]
 
 


### PR DESCRIPTION
Do not merge - A bad fix for `Query.Children` with lots of code copied and pasted from `elm-html-query`.  Makes tests from https://github.com/eeue56/elm-html-test/pull/11 pass. Demonstrates why https://github.com/eeue56/elm-html-query/pull/2 is needed. 

cc - @rtfeldman 