### PR TITLE
Add events

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -13,7 +13,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "eeue56/elm-html-in-elm": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-html-in-elm": "3.0.0 <= v < 4.0.0",
         "eeue56/elm-html-query": "1.1.0 <= v < 2.0.0",
         "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -8,7 +8,8 @@
     ],
     "exposed-modules": [
         "Test.Html.Selector",
-        "Test.Html.Query"
+        "Test.Html.Query",
+        "Test.Html.Events"
     ],
     "native-modules": true,
     "dependencies": {

--- a/examples/ExampleApp.elm
+++ b/examples/ExampleApp.elm
@@ -15,16 +15,16 @@ exampleModel =
 
 
 type Msg
-    = SomeMsg
-    | AnotherMsg
+    = GoToHome
+    | GoToExamples
 
 
 view : Model -> Html Msg
 view model =
     div [ class "container" ]
         [ header [ class "funky themed", id "heading" ]
-            [ a [ href "http://elm-lang.org", onClick SomeMsg ] [ text "home" ]
-            , a [ href "http://elm-lang.org/examples" ] [ text "examples" ]
+            [ a [ href "http://elm-lang.org", onClick GoToHome ] [ text "home" ]
+            , a [ href "http://elm-lang.org/examples", onClick GoToExamples ] [ text "examples" ]
             , a [ href "http://elm-lang.org/docs" ] [ text "docs" ]
             ]
         , section [ class "funky themed", id "section" ]

--- a/examples/ExampleApp.elm
+++ b/examples/ExampleApp.elm
@@ -2,6 +2,7 @@ module ExampleApp exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 
 
 type alias Model =
@@ -13,11 +14,16 @@ exampleModel =
     ()
 
 
-view : Model -> Html msg
+type Msg
+    = SomeMsg
+    | AnotherMsg
+
+
+view : Model -> Html Msg
 view model =
     div [ class "container" ]
         [ header [ class "funky themed", id "heading" ]
-            [ a [ href "http://elm-lang.org" ] [ text "home" ]
+            [ a [ href "http://elm-lang.org", onClick SomeMsg ] [ text "home" ]
             , a [ href "http://elm-lang.org/examples" ] [ text "examples" ]
             , a [ href "http://elm-lang.org/docs" ] [ text "docs" ]
             ]

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -1,12 +1,13 @@
 port module Main exposing (..)
 
-import Test.Runner.Node exposing (run, TestProgram)
+import ExampleApp exposing (Msg(..), exampleModel, view)
 import Expect
-import Test exposing (..)
 import Json.Encode exposing (Value)
+import Test exposing (..)
+import Test.Html.Events as Events
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
-import ExampleApp exposing (view, exampleModel)
+import Test.Runner.Node exposing (TestProgram, run)
 
 
 main : TestProgram
@@ -86,4 +87,31 @@ testView =
                         |> Query.find [ tag "ul" ]
                         |> Query.findAll [ tag "li" ]
                         |> Query.each (Query.has [ classes [ "list-item", "themed" ] ])
+            , test "expect first a to send SomeMsg onClick" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.first
+                        |> Events.trigger "click" "{}"
+                        |> Expect.equal (Ok SomeMsg)
+            , test "(this should fail) expect first a to send AnotherMsg onClick, even though it sends SomeMsg" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.first
+                        |> Events.trigger "click" "{}"
+                        |> Expect.equal (Ok AnotherMsg)
+            , test "(this should fail) expect first a to trigger a blur event, even though it doesn't have one" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.first
+                        |> Events.trigger "blur" "{}"
+                        |> Expect.equal (Ok SomeMsg)
+            , test "(this should fail) expect text to trigger onClick, even though it is a text" <|
+                \() ->
+                    output
+                        |> Query.find [ text "home" ]
+                        |> Events.trigger "click" "{}"
+                        |> Expect.equal (Ok SomeMsg)
             ]

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -87,31 +87,31 @@ testView =
                         |> Query.find [ tag "ul" ]
                         |> Query.findAll [ tag "li" ]
                         |> Query.each (Query.has [ classes [ "list-item", "themed" ] ])
-            , test "expect first a to send SomeMsg onClick" <|
+            , test "expect first a to send GoToHome onClick" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
                         |> Events.simulate Click
-                        |> Expect.equal (Ok SomeMsg)
-            , test "(this should fail) expect first a to return AnotherMsg on click, even though it returns SomeMsg" <|
+                        |> Expect.equal (Ok GoToHome)
+            , test "(this should fail) expect first a to return GoToExamples on click, even though it returns GoToHome" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
                         |> Events.simulate Click
-                        |> Expect.equal (Ok AnotherMsg)
+                        |> Expect.equal (Ok GoToExamples)
             , test "(this should fail) expect first a to return a msg for a blur event, even though it doesn't have one" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
                         |> Events.simulate Blur
-                        |> Expect.equal (Ok SomeMsg)
+                        |> Expect.equal (Ok GoToHome)
             , test "(this should fail) expect text to return a msg for click, even though it is a text" <|
                 \() ->
                     output
                         |> Query.find [ text "home" ]
                         |> Events.simulate Click
-                        |> Expect.equal (Ok SomeMsg)
+                        |> Expect.equal (Ok GoToHome)
             ]

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -92,26 +92,26 @@ testView =
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.msgFor "click" "{}"
+                        |> Events.simulate "click" "{}"
                         |> Expect.equal (Ok SomeMsg)
             , test "(this should fail) expect first a to return AnotherMsg on click, even though it returns SomeMsg" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.msgFor "click" "{}"
+                        |> Events.simulate "click" "{}"
                         |> Expect.equal (Ok AnotherMsg)
             , test "(this should fail) expect first a to return a msg for a blur event, even though it doesn't have one" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.msgFor "blur" "{}"
+                        |> Events.simulate "blur" "{}"
                         |> Expect.equal (Ok SomeMsg)
             , test "(this should fail) expect text to return a msg for click, even though it is a text" <|
                 \() ->
                     output
                         |> Query.find [ text "home" ]
-                        |> Events.msgFor "click" "{}"
+                        |> Events.simulate "click" "{}"
                         |> Expect.equal (Ok SomeMsg)
             ]

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -4,7 +4,7 @@ import ExampleApp exposing (Msg(..), exampleModel, view)
 import Expect
 import Json.Encode exposing (Value)
 import Test exposing (..)
-import Test.Html.Events as Events
+import Test.Html.Events as Events exposing (Event(..))
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
 import Test.Runner.Node exposing (TestProgram, run)
@@ -92,26 +92,26 @@ testView =
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.simulate "click" "{}"
+                        |> Events.simulate Click
                         |> Expect.equal (Ok SomeMsg)
             , test "(this should fail) expect first a to return AnotherMsg on click, even though it returns SomeMsg" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.simulate "click" "{}"
+                        |> Events.simulate Click
                         |> Expect.equal (Ok AnotherMsg)
             , test "(this should fail) expect first a to return a msg for a blur event, even though it doesn't have one" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.simulate "blur" "{}"
+                        |> Events.simulate Blur
                         |> Expect.equal (Ok SomeMsg)
             , test "(this should fail) expect text to return a msg for click, even though it is a text" <|
                 \() ->
                     output
                         |> Query.find [ text "home" ]
-                        |> Events.simulate "click" "{}"
+                        |> Events.simulate Click
                         |> Expect.equal (Ok SomeMsg)
             ]

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -92,26 +92,26 @@ testView =
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.trigger "click" "{}"
+                        |> Events.msgFor "click" "{}"
                         |> Expect.equal (Ok SomeMsg)
-            , test "(this should fail) expect first a to send AnotherMsg onClick, even though it sends SomeMsg" <|
+            , test "(this should fail) expect first a to return AnotherMsg on click, even though it returns SomeMsg" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.trigger "click" "{}"
+                        |> Events.msgFor "click" "{}"
                         |> Expect.equal (Ok AnotherMsg)
-            , test "(this should fail) expect first a to trigger a blur event, even though it doesn't have one" <|
+            , test "(this should fail) expect first a to return a msg for a blur event, even though it doesn't have one" <|
                 \() ->
                     output
                         |> Query.findAll [ tag "a" ]
                         |> Query.first
-                        |> Events.trigger "blur" "{}"
+                        |> Events.msgFor "blur" "{}"
                         |> Expect.equal (Ok SomeMsg)
-            , test "(this should fail) expect text to trigger onClick, even though it is a text" <|
+            , test "(this should fail) expect text to return a msg for click, even though it is a text" <|
                 \() ->
                     output
                         |> Query.find [ text "home" ]
-                        |> Events.trigger "click" "{}"
+                        |> Events.msgFor "click" "{}"
                         |> Expect.equal (Ok SomeMsg)
             ]

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -10,7 +10,7 @@
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "eeue56/elm-html-in-elm": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-html-in-elm": "3.0.0 <= v < 4.0.0",
         "eeue56/elm-html-query": "1.1.0 <= v < 2.0.0",
         "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",

--- a/src/Html/Inert.elm
+++ b/src/Html/Inert.elm
@@ -9,13 +9,14 @@ import Html exposing (Html)
 import ElmHtml.InternalTypes exposing (decodeElmHtml, ElmHtml)
 import Native.HtmlAsJson
 
+
 type Node
     = Node ElmHtml
 
 
 fromHtml : Html msg -> Node
 fromHtml html =
-    case Json.Decode.decodeString decodeElmHtml (toJsonString html) of
+    case Json.Decode.decodeValue decodeElmHtml (toJson html) of
         Ok elmHtml ->
             Node elmHtml
 
@@ -27,11 +28,12 @@ fromElmHtml : ElmHtml -> Node
 fromElmHtml =
     Node
 
+
 {-| Convert a Html node to a Json string
 -}
-toJsonString : Html a -> String
-toJsonString node =
-    Native.HtmlAsJson.toJsonString node
+toJson : Html a -> Json.Decode.Value
+toJson node =
+    Native.HtmlAsJson.toJson node
 
 
 toElmHtml : Node -> ElmHtml

--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -9,15 +9,9 @@ var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
         return vNode;
     }
 
-    // stringify needed to strip functions - can performance-optimize this later!
     return {
-        toJsonString: function(html) {
-            var asString = JSON.stringify(forceThunks(html));
-
-            if (typeof asString === "undefined"){
-                return "";
-            }
-            return asString;
+        toJson: function(html) {
+            return forceThunks(html);
         },
         getEventDecoder: F2(function (name, events) {
             var event = events[name];

--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -18,6 +18,15 @@ var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
                 return "";
             }
             return asString;
-        }
+        },
+        getEventDecoder: F2(function (name, events) {
+            var event = events[name];
+            if (!event) return { ctor: 'Nothing' };
+
+            return {
+              ctor: 'Just',
+              _0: event.decoder
+            }
+        })
     };
 })();

--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -15,6 +15,9 @@ var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
         },
         eventDecoder: function (event) {
             return event.decoder;
+        },
+        taggerFunction: function (tagger) {
+            return tagger;
         }
     };
 })();

--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -13,7 +13,7 @@ var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
         toJson: function(html) {
             return forceThunks(html);
         },
-        getEventDecoder: F2(function (name, events) {
+        eventDecoder: F2(function (name, events) {
             var event = events[name];
             if (!event) return { ctor: 'Nothing' };
 

--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -13,11 +13,8 @@ var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
         toJson: function(html) {
             return forceThunks(html);
         },
-        eventDecoder: F2(function (eventName, events) {
-            var event = events[eventName];
-            if (!event) return _elm_lang$core$Result$Err('Event ' + eventName + ' not found');
-
-            return _elm_lang$core$Result$Ok(event.decoder);
-        })
+        eventDecoder: function (event) {
+            return event.decoder;
+        }
     };
 })();

--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -13,14 +13,11 @@ var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
         toJson: function(html) {
             return forceThunks(html);
         },
-        eventDecoder: F2(function (name, events) {
-            var event = events[name];
-            if (!event) return { ctor: 'Nothing' };
+        eventDecoder: F2(function (eventName, events) {
+            var event = events[eventName];
+            if (!event) return _elm_lang$core$Result$Err('Event ' + eventName + ' not found');
 
-            return {
-              ctor: 'Just',
-              _0: event.decoder
-            }
+            return _elm_lang$core$Result$Ok(event.decoder);
         })
     };
 })();

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -40,21 +40,21 @@ getEventDecoder =
 
 -}
 simulate : String -> String -> Query.Single -> Result String msg
-simulate name event (QueryInternal.Single showTrace query) =
+simulate eventName event (QueryInternal.Single showTrace query) =
     QueryInternal.traverse query
-        |> Result.andThen (QueryInternal.verifySingle name)
+        |> Result.andThen (QueryInternal.verifySingle eventName)
         |> Result.mapError (QueryInternal.queryErrorToString query)
-        |> Result.andThen (findEvent name)
+        |> Result.andThen (findEvent eventName)
         |> Result.andThen (\decoder -> decodeString decoder event)
 
 
 findEvent : String -> ElmHtml -> Result String (Json.Decode.Decoder msg)
-findEvent name element =
+findEvent eventName element =
     case element of
         NodeEntry node ->
             node.facts.events
-                |> Maybe.andThen (getEventDecoder name)
-                |> Result.fromMaybe ("Could not find a " ++ name ++ " event for " ++ QueryInternal.prettyPrint element)
+                |> Maybe.andThen (getEventDecoder eventName)
+                |> Result.fromMaybe ("Could not find a " ++ eventName ++ " event for " ++ QueryInternal.prettyPrint element)
 
         _ ->
-            Err ("Found element is not a common HTML Node, therefore could not get msg for " ++ name ++ " on it. Element found: " ++ QueryInternal.prettyPrint element)
+            Err ("Found element is not a common HTML Node, therefore could not get msg for " ++ eventName ++ " on it. Element found: " ++ QueryInternal.prettyPrint element)

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -42,12 +42,6 @@ type Event
 
 {-| Gets a Msg produced by a node when an event is simulated.
 
-    import Html
-    import Html.Events exposing (onInput)
-    import Test.Html.Query as Query
-    import Test.Html.Events as Events
-    import Test exposing (test)
-
     type Msg
         = Change String
 
@@ -137,13 +131,13 @@ findEvent eventName element =
     case element of
         NodeEntry node ->
             node.facts.events
-                |> Maybe.andThen (getEventDecoder eventName)
+                |> Maybe.andThen (eventDecoder eventName)
                 |> Result.fromMaybe ("Could not find a " ++ eventName ++ " event for " ++ QueryInternal.prettyPrint element)
 
         _ ->
             Err ("Found element is not a common HTML Node, therefore could not get msg for " ++ eventName ++ " on it. Element found: " ++ QueryInternal.prettyPrint element)
 
 
-getEventDecoder : String -> Json.Decode.Value -> Maybe (Json.Decode.Decoder msg)
-getEventDecoder =
-    Native.HtmlAsJson.getEventDecoder
+eventDecoder : String -> Json.Decode.Value -> Maybe (Json.Decode.Decoder msg)
+eventDecoder eventName event =
+    Native.HtmlAsJson.eventDecoder eventName event

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -1,11 +1,11 @@
 module Test.Html.Events
     exposing
-        ( msgFor
+        ( simulate
         )
 
 {-|
 
-@docs msgFor
+@docs simulate
 -}
 
 import ElmHtml.InternalTypes exposing (ElmHtml(NodeEntry))
@@ -35,12 +35,12 @@ getEventDecoder =
         \() ->
             Html.input [ onInput Change ] [ ]
                 |> Query.fromHtml
-                |> Events.msgFor "input" "{\"target\": {\"value\": \"cats\"}}"
+                |> Events.simulate "input" "{\"target\": {\"value\": \"cats\"}}"
                 |> Expect.equal (Ok <| Change "cats")
 
 -}
-msgFor : String -> String -> Query.Single -> Result String msg
-msgFor name event (QueryInternal.Single showTrace query) =
+simulate : String -> String -> Query.Single -> Result String msg
+simulate name event (QueryInternal.Single showTrace query) =
     QueryInternal.traverse query
         |> Result.andThen (QueryInternal.verifySingle name)
         |> Result.mapError (QueryInternal.queryErrorToString query)

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -1,0 +1,43 @@
+module Test.Html.Events
+    exposing
+        ( trigger
+        )
+
+{-|
+
+@docs trigger
+-}
+
+import ElmHtml.InternalTypes exposing (ElmHtml(NodeEntry))
+import Json.Decode exposing (decodeString, decodeValue, field, string)
+import Native.HtmlAsJson
+import Test.Html.Query as Query
+import Test.Html.Query.Internal as QueryInternal
+
+
+getEventDecoder : String -> Json.Decode.Value -> Maybe (Json.Decode.Decoder msg)
+getEventDecoder =
+    Native.HtmlAsJson.getEventDecoder
+
+
+{-| Trigger events
+-}
+trigger : String -> String -> Query.Single -> Result String msg
+trigger name event (QueryInternal.Single showTrace query) =
+    QueryInternal.traverse query
+        |> Result.andThen (QueryInternal.verifySingle <| "Trigger " ++ name)
+        |> Result.mapError (QueryInternal.queryErrorToString query)
+        |> Result.andThen (findEvent name)
+        |> Result.andThen (\decoder -> decodeString decoder event)
+
+
+findEvent : String -> ElmHtml -> Result String (Json.Decode.Decoder msg)
+findEvent name element =
+    case element of
+        NodeEntry node ->
+            node.facts.events
+                |> Maybe.andThen (getEventDecoder name)
+                |> Result.fromMaybe ("Could not find a " ++ name ++ " event for " ++ QueryInternal.prettyPrint element)
+
+        _ ->
+            Err ("Found element is not a common HTML Node, therefore could not trigger " ++ name ++ " on it. Element found: " ++ QueryInternal.prettyPrint element)

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -13,6 +13,7 @@ by the event is returned so you can test it
 
 -}
 
+import Dict
 import ElmHtml.InternalTypes exposing (ElmHtml(..))
 import Json.Decode exposing (decodeString)
 import Json.Encode exposing (bool, encode, object, string)
@@ -134,8 +135,9 @@ findEvent eventName element =
 
         nodeEventDecoder node =
             node.facts.events
-                |> Maybe.map (eventDecoder eventName)
-                |> Maybe.withDefault (Err <| elementOutput ++ " has no events")
+                |> Dict.get eventName
+                |> Maybe.map eventDecoder
+                |> Result.fromMaybe (elementOutput ++ " has no " ++ eventName ++ " event")
     in
         case element of
             TextTag _ ->
@@ -154,6 +156,6 @@ findEvent eventName element =
                 Err ("Unknown element found. Could not simulate " ++ eventName ++ " on it.")
 
 
-eventDecoder : String -> Json.Decode.Value -> Result String (Json.Decode.Decoder msg)
-eventDecoder eventName event =
-    Native.HtmlAsJson.eventDecoder eventName event
+eventDecoder : Json.Decode.Value -> Json.Decode.Decoder msg
+eventDecoder event =
+    Native.HtmlAsJson.eventDecoder event

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -20,7 +20,24 @@ getEventDecoder =
     Native.HtmlAsJson.getEventDecoder
 
 
-{-| msgFor events
+{-| Gets a Msg produced by a node when an event is triggered.
+
+    import Html
+    import Html.Events exposing (onInput)
+    import Test.Html.Query as Query
+    import Test.Html.Events as Events
+    import Test exposing (test)
+
+    type Msg
+        = Change String
+
+    test "Input produces expected Msg" <|
+        \() ->
+            Html.input [ onInput Change ] [ ]
+                |> Query.fromHtml
+                |> Events.msgFor "input" "{\"target\": {\"value\": \"cats\"}}"
+                |> Expect.equal (Ok <| Change "cats")
+
 -}
 msgFor : String -> String -> Query.Single -> Result String msg
 msgFor name event (QueryInternal.Single showTrace query) =

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -5,7 +5,13 @@ module Test.Html.Events
 
 {-|
 
+This module allows you to simulate events on Html nodes, the Msg generated
+by the event is returned so you can test it
+
+## Simulating Events
+
 @docs simulate
+
 -}
 
 import ElmHtml.InternalTypes exposing (ElmHtml(NodeEntry))
@@ -20,7 +26,7 @@ getEventDecoder =
     Native.HtmlAsJson.getEventDecoder
 
 
-{-| Gets a Msg produced by a node when an event is triggered.
+{-| Gets a Msg produced by a node when an event is simulated.
 
     import Html
     import Html.Events exposing (onInput)

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -1,11 +1,11 @@
 module Test.Html.Events
     exposing
-        ( trigger
+        ( msgFor
         )
 
 {-|
 
-@docs trigger
+@docs msgFor
 -}
 
 import ElmHtml.InternalTypes exposing (ElmHtml(NodeEntry))
@@ -20,12 +20,12 @@ getEventDecoder =
     Native.HtmlAsJson.getEventDecoder
 
 
-{-| Trigger events
+{-| msgFor events
 -}
-trigger : String -> String -> Query.Single -> Result String msg
-trigger name event (QueryInternal.Single showTrace query) =
+msgFor : String -> String -> Query.Single -> Result String msg
+msgFor name event (QueryInternal.Single showTrace query) =
     QueryInternal.traverse query
-        |> Result.andThen (QueryInternal.verifySingle <| "Trigger " ++ name)
+        |> Result.andThen (QueryInternal.verifySingle name)
         |> Result.mapError (QueryInternal.queryErrorToString query)
         |> Result.andThen (findEvent name)
         |> Result.andThen (\decoder -> decodeString decoder event)
@@ -40,4 +40,4 @@ findEvent name element =
                 |> Result.fromMaybe ("Could not find a " ++ name ++ " event for " ++ QueryInternal.prettyPrint element)
 
         _ ->
-            Err ("Found element is not a common HTML Node, therefore could not trigger " ++ name ++ " on it. Element found: " ++ QueryInternal.prettyPrint element)
+            Err ("Found element is not a common HTML Node, therefore could not get msg for " ++ name ++ " on it. Element found: " ++ QueryInternal.prettyPrint element)

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -1,7 +1,7 @@
 module Events exposing (..)
 
 import Expect
-import Html exposing (Html, button, div, text)
+import Html exposing (Html, button, div, text, input)
 import Html.Attributes as Attr exposing (href)
 import Html.Events exposing (onClick, onInput)
 import Html.Lazy as Lazy
@@ -38,12 +38,20 @@ all =
                     |>
                         Result.map (always MappedSampleMsg)
                     |> Expect.equal (Ok MappedSampleMsg)
+        , test "triggers input on element with transformation" <|
+            \() ->
+                Query.fromHtml sampleInput
+                    |> Query.findAll [ tag "input" ]
+                    |> Query.first
+                    |> Events.trigger "input" "{\"target\": {\"value\": \"cats\"}}"
+                    |> Expect.equal (Ok <| SampleInputMsg "CATS")
         ]
 
 
 type Msg
     = SampleMsg
     | MappedSampleMsg
+    | SampleInputMsg String
 
 
 sampleHtml : Html Msg
@@ -66,4 +74,11 @@ sampleMappedHtml : Html Msg
 sampleMappedHtml =
     div [ Attr.class "container" ]
         [ Html.map (always MappedSampleMsg) (button [ onClick SampleMsg ] [ text "click me" ])
+        ]
+
+
+sampleInput : Html Msg
+sampleInput =
+    div [ Attr.class "container" ]
+        [ input [ onInput (String.toUpper >> SampleInputMsg) ] []
         ]

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -19,21 +19,21 @@ all =
                 Query.fromHtml sampleHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.msgFor "click" "{}"
+                    |> Events.simulate "click" "{}"
                     |> Expect.equal (Ok SampleMsg)
         , test "returns msg for click on lazy html" <|
             \() ->
                 Query.fromHtml sampleLazyHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.msgFor "click" "{}"
+                    |> Events.simulate "click" "{}"
                     |> Expect.equal (Ok SampleMsg)
         , test "returns msg for click on mapped html" <|
             \() ->
                 Query.fromHtml sampleMappedHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.msgFor "click" "{}"
+                    |> Events.simulate "click" "{}"
                     -- TODO: Html.Map is ignored when traversing the DOM, need to fix it to avoid repeated mapping on tests like this
                     |>
                         Result.map (always MappedSampleMsg)
@@ -43,7 +43,7 @@ all =
                 Query.fromHtml sampleInput
                     |> Query.findAll [ tag "input" ]
                     |> Query.first
-                    |> Events.msgFor "input" "{\"target\": {\"value\": \"cats\"}}"
+                    |> Events.simulate "input" "{\"target\": {\"value\": \"cats\"}}"
                     |> Expect.equal (Ok <| SampleInputMsg "CATS")
         ]
 

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -1,12 +1,13 @@
 module Events exposing (..)
 
 import Expect
-import Html exposing (Html, button, div, text, input)
+import Html exposing (Html, button, div, input, text)
 import Html.Attributes as Attr exposing (href)
-import Html.Events exposing (onClick, onInput)
+import Html.Events exposing (..)
 import Html.Lazy as Lazy
+import Json.Decode
 import Test exposing (..)
-import Test.Html.Events as Events
+import Test.Html.Events as Events exposing (Event(..))
 import Test.Html.Query as Query exposing (Single)
 import Test.Html.Selector exposing (tag)
 
@@ -19,32 +20,52 @@ all =
                 Query.fromHtml sampleHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.simulate "click" "{}"
+                    |> Events.simulate Click
                     |> Expect.equal (Ok SampleMsg)
         , test "returns msg for click on lazy html" <|
             \() ->
                 Query.fromHtml sampleLazyHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.simulate "click" "{}"
+                    |> Events.simulate Click
                     |> Expect.equal (Ok SampleMsg)
         , test "returns msg for click on mapped html" <|
             \() ->
                 Query.fromHtml sampleMappedHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.simulate "click" "{}"
+                    |> Events.simulate Click
                     -- TODO: Html.Map is ignored when traversing the DOM, need to fix it to avoid repeated mapping on tests like this
                     |>
                         Result.map (always MappedSampleMsg)
                     |> Expect.equal (Ok MappedSampleMsg)
         , test "returns msg for input with transformation" <|
             \() ->
-                Query.fromHtml sampleInput
-                    |> Query.findAll [ tag "input" ]
-                    |> Query.first
-                    |> Events.simulate "input" "{\"target\": {\"value\": \"cats\"}}"
+                input [ onInput (String.toUpper >> SampleInputMsg) ] []
+                    |> Query.fromHtml
+                    |> Events.simulate (Input "cats")
                     |> Expect.equal (Ok <| SampleInputMsg "CATS")
+        , test "returns msg for check event" <|
+            \() ->
+                input [ onCheck SampleCheckedMsg ] []
+                    |> Query.fromHtml
+                    |> Events.simulate (Check True)
+                    |> Expect.equal (Ok <| SampleCheckedMsg True)
+        , test "returns msg for custom event" <|
+            \() ->
+                input [ on "keyup" (Json.Decode.map SampleKeyUpMsg keyCode) ] []
+                    |> Query.fromHtml
+                    |> Events.simulate (CustomEvent "keyup" "{\"keyCode\": 5}")
+                    |> Expect.equal (Ok <| SampleKeyUpMsg 5)
+        , testEvent onDoubleClick DoubleClick
+        , testEvent onMouseDown MouseDown
+        , testEvent onMouseUp MouseUp
+        , testEvent onMouseLeave MouseLeave
+        , testEvent onMouseOver MouseOver
+        , testEvent onMouseOut MouseOut
+        , testEvent onSubmit Submit
+        , testEvent onBlur Blur
+        , testEvent onFocus Focus
         ]
 
 
@@ -52,6 +73,8 @@ type Msg
     = SampleMsg
     | MappedSampleMsg
     | SampleInputMsg String
+    | SampleCheckedMsg Bool
+    | SampleKeyUpMsg Int
 
 
 sampleHtml : Html Msg
@@ -77,8 +100,11 @@ sampleMappedHtml =
         ]
 
 
-sampleInput : Html Msg
-sampleInput =
-    div [ Attr.class "container" ]
-        [ input [ onInput (String.toUpper >> SampleInputMsg) ] []
-        ]
+testEvent : (Msg -> Html.Attribute msg) -> Event -> Test
+testEvent testOn event =
+    test ("returns msg for " ++ (toString event) ++ " event") <|
+        \() ->
+            input [ testOn SampleMsg ] []
+                |> Query.fromHtml
+                |> Events.simulate event
+                |> Expect.equal (Ok SampleMsg)

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -14,36 +14,36 @@ import Test.Html.Selector exposing (tag)
 all : Test
 all =
     describe "trigerring events"
-        [ test "triggers click on element" <|
+        [ test "returns msg for click on element" <|
             \() ->
                 Query.fromHtml sampleHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.trigger "click" "{}"
+                    |> Events.msgFor "click" "{}"
                     |> Expect.equal (Ok SampleMsg)
-        , test "triggers click on lazy html" <|
+        , test "returns msg for click on lazy html" <|
             \() ->
                 Query.fromHtml sampleLazyHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.trigger "click" "{}"
+                    |> Events.msgFor "click" "{}"
                     |> Expect.equal (Ok SampleMsg)
-        , test "triggers click on mapped html" <|
+        , test "returns msg for click on mapped html" <|
             \() ->
                 Query.fromHtml sampleMappedHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.trigger "click" "{}"
+                    |> Events.msgFor "click" "{}"
                     -- TODO: Html.Map is ignored when traversing the DOM, need to fix it to avoid repeated mapping on tests like this
                     |>
                         Result.map (always MappedSampleMsg)
                     |> Expect.equal (Ok MappedSampleMsg)
-        , test "triggers input on element with transformation" <|
+        , test "returns msg for input with transformation" <|
             \() ->
                 Query.fromHtml sampleInput
                     |> Query.findAll [ tag "input" ]
                     |> Query.first
-                    |> Events.trigger "input" "{\"target\": {\"value\": \"cats\"}}"
+                    |> Events.msgFor "input" "{\"target\": {\"value\": \"cats\"}}"
                     |> Expect.equal (Ok <| SampleInputMsg "CATS")
         ]
 

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -1,0 +1,66 @@
+module Events exposing (..)
+
+import Html exposing (Html, div, button, text)
+import Html.Lazy as Lazy
+import Html.Attributes as Attr exposing (href)
+import Html.Events exposing (onClick)
+import Test.Html.Query as Query exposing (Single)
+import Test.Html.Events as Events
+import Test.Html.Selector exposing (tag)
+import Test exposing (..)
+import Expect
+
+
+all : Test
+all =
+    let
+        html =
+            [ htmlOutput, lazyOutput ]
+    in
+        Test.concat <|
+            List.concatMap (\f -> List.map f html)
+                [ testEvents
+                ]
+
+
+testEvents : Single -> Test
+testEvents output =
+    describe "trigerring events"
+        [ test "triggers click on element" <|
+            \() ->
+                output
+                    |> Query.findAll [ tag "button" ]
+                    |> Query.first
+                    |> Events.trigger "click" "{}"
+                    |> Expect.equal (Ok SampleMsg)
+        ]
+
+
+htmlOutput : Single
+htmlOutput =
+    Query.fromHtml sampleHtml
+
+
+lazyOutput : Single
+lazyOutput =
+    Query.fromHtml sampleLazyHtml
+
+
+type Msg
+    = SampleMsg
+
+
+sampleHtml : Html Msg
+sampleHtml =
+    div [ Attr.class "container" ]
+        [ button [ onClick SampleMsg ] [ text "click me" ]
+        ]
+
+
+sampleLazyHtml : Html Msg
+sampleLazyHtml =
+    div [ Attr.class "container" ]
+        [ Lazy.lazy
+            (\str -> button [ onClick SampleMsg ] [ text str ])
+            "click me"
+        ]

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -35,10 +35,14 @@ all =
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
                     |> Events.simulate Click
-                    -- TODO: Html.Map is ignored when traversing the DOM, need to fix it to avoid repeated mapping on tests like this
-                    |>
-                        Result.map (always MappedSampleMsg)
                     |> Expect.equal (Ok MappedSampleMsg)
+        , test "returns msg for click on deep mapped html" <|
+            \() ->
+                Query.fromHtml deepMappedHtml
+                    |> Query.findAll [ tag "input" ]
+                    |> Query.first
+                    |> Events.simulate (Input "foo")
+                    |> Expect.equal (Ok (SampleInputMsg "foobar"))
         , test "returns msg for input with transformation" <|
             \() ->
                 input [ onInput (String.toUpper >> SampleInputMsg) ] []
@@ -97,6 +101,21 @@ sampleMappedHtml : Html Msg
 sampleMappedHtml =
     div [ Attr.class "container" ]
         [ Html.map (always MappedSampleMsg) (button [ onClick SampleMsg ] [ text "click me" ])
+        ]
+
+
+deepMappedHtml : Html Msg
+deepMappedHtml =
+    div []
+        [ Html.map (SampleInputMsg)
+            (div []
+                [ Html.map (\msg -> msg ++ "bar")
+                    (div []
+                        [ input [ onInput identity ] []
+                        ]
+                    )
+                ]
+            )
         ]
 
 

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -1,53 +1,49 @@
 module Events exposing (..)
 
-import Html exposing (Html, div, button, text)
-import Html.Lazy as Lazy
-import Html.Attributes as Attr exposing (href)
-import Html.Events exposing (onClick)
-import Test.Html.Query as Query exposing (Single)
-import Test.Html.Events as Events
-import Test.Html.Selector exposing (tag)
-import Test exposing (..)
 import Expect
+import Html exposing (Html, button, div, text)
+import Html.Attributes as Attr exposing (href)
+import Html.Events exposing (onClick, onInput)
+import Html.Lazy as Lazy
+import Test exposing (..)
+import Test.Html.Events as Events
+import Test.Html.Query as Query exposing (Single)
+import Test.Html.Selector exposing (tag)
 
 
 all : Test
 all =
-    let
-        html =
-            [ htmlOutput, lazyOutput ]
-    in
-        Test.concat <|
-            List.concatMap (\f -> List.map f html)
-                [ testEvents
-                ]
-
-
-testEvents : Single -> Test
-testEvents output =
     describe "trigerring events"
         [ test "triggers click on element" <|
             \() ->
-                output
+                Query.fromHtml sampleHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
                     |> Events.trigger "click" "{}"
                     |> Expect.equal (Ok SampleMsg)
+        , test "triggers click on lazy html" <|
+            \() ->
+                Query.fromHtml sampleLazyHtml
+                    |> Query.findAll [ tag "button" ]
+                    |> Query.first
+                    |> Events.trigger "click" "{}"
+                    |> Expect.equal (Ok SampleMsg)
+        , test "triggers click on mapped html" <|
+            \() ->
+                Query.fromHtml sampleMappedHtml
+                    |> Query.findAll [ tag "button" ]
+                    |> Query.first
+                    |> Events.trigger "click" "{}"
+                    -- TODO: Html.Map is ignored when traversing the DOM, need to fix it to avoid repeated mapping on tests like this
+                    |>
+                        Result.map (always MappedSampleMsg)
+                    |> Expect.equal (Ok MappedSampleMsg)
         ]
-
-
-htmlOutput : Single
-htmlOutput =
-    Query.fromHtml sampleHtml
-
-
-lazyOutput : Single
-lazyOutput =
-    Query.fromHtml sampleLazyHtml
 
 
 type Msg
     = SampleMsg
+    | MappedSampleMsg
 
 
 sampleHtml : Html Msg
@@ -63,4 +59,11 @@ sampleLazyHtml =
         [ Lazy.lazy
             (\str -> button [ onClick SampleMsg ] [ text str ])
             "click me"
+        ]
+
+
+sampleMappedHtml : Html Msg
+sampleMappedHtml =
+    div [ Attr.class "container" ]
+        [ Html.map (always MappedSampleMsg) (button [ onClick SampleMsg ] [ text "click me" ])
         ]

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -5,12 +5,14 @@ import Test exposing (..)
 import Json.Encode exposing (Value)
 import TestExample
 import Queries
+import Events
 
 
 main : TestProgram
 main =
     [ TestExample.all
     , Queries.all
+    , Events.all
     ]
         |> Test.concat
         |> run emit

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -11,7 +11,7 @@
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "eeue56/elm-html-in-elm": "2.0.0 <= v < 3.0.0",
+        "eeue56/elm-html-in-elm": "3.0.0 <= v < 4.0.0",
         "eeue56/elm-html-query": "1.1.0 <= v < 2.0.0",
         "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",


### PR DESCRIPTION
Hello,

I was trying to add a way to trigger events and check its Msg for elm-html-test, the reasons for that are:

1 - Be able to unit test what messages an html element is producing
2 - (most important for me) being able to later on elm-testable (rewrite-native branch) write a full integration test like this:

```elm
webSocketsComponent
    |> startForTest
    |> find [ tag "input" ]
    |> trigger "input" "{\"target\": {\"value\": \"dogs\"}}"
    |> find [ tag "button" ]
    |> trigger "click" "{}"
    |> assertCalled (WebSocket.send WebSockets.echoServer "dogs")
```

So, to test that an Elm app is working properly and functions are fully integrated I don't want to manage the messages and updates myself, I just want to simulate events around the screen and check that the right places changed, or that some external data was sent (like this websocket)

This is how I test things in CaronaBoard (https://github.com/CaronaBoard/caronaboard/tree/master/tests/Integration) and it has been a great way to test IMHO. But for that I use my own fork of elm-testable, I want to switch to elm-testable#rewrite-native and deprecate my fork, but I need this feature first.

So, my idea was for `elm-html-test` to just return the Msg from a triggered component, and `elm-testable` could use those messages to update the state of the app.

I got it working just fine with `onClick`, but then I had two problems:

1 - On parsing, Html.Map is ignored, so the Msgs do not get mapped, I believe this issue is not a blocker, since not everyone uses Html.Map, or we can manually remap on the test for now
2 - Since we stringify the HTML, the functions are stripped off, this was intentional so far, but now we need the functions if we want the trigger to work with `onInput` too, not only clicks

Number 2 is a more profound change, so idk if you have more ideas with taking this forward, or if you want to.

Meanwhile, I was trying to hack the html to ElmHtml parsing directly on native, rather than using Json.Decode (which requires us to strip functions)

Cheers!