### PR TITLE
Query.contains [WIP]

### DIFF
--- a/src/Test/Html/Descendant.elm
+++ b/src/Test/Html/Descendant.elm
@@ -1,0 +1,30 @@
+module Test.Html.Descendant exposing (isDescendant)
+
+import Html exposing (Html)
+import ElmHtml.InternalTypes exposing (ElmHtml(..))
+import Html.Inert exposing (fromHtml, toElmHtml)
+
+
+isDescendant : List (ElmHtml msg) -> ElmHtml msg -> Bool
+isDescendant html potentialDescendant =
+    case html of
+        [] ->
+            False
+
+        current :: rest ->
+            if current == potentialDescendant then
+                True
+            else
+                isDescendant
+                    (prependChildren current rest)
+                    potentialDescendant
+
+
+prependChildren : ElmHtml msg -> List (ElmHtml msg) -> List (ElmHtml msg)
+prependChildren parentNode nodeList =
+    case parentNode of
+        NodeEntry { children } ->
+            (List.concat [ children, nodeList ])
+
+        _ ->
+            nodeList

--- a/src/Test/Html/Query/Internal.elm
+++ b/src/Test/Html/Query/Internal.elm
@@ -5,6 +5,7 @@ import Html.Inert as Inert exposing (Node)
 import ElmHtml.InternalTypes exposing (ElmHtml(..))
 import ElmHtml.ToString exposing (nodeToStringWithOptions)
 import Expect exposing (Expectation)
+import Test.Html.Descendant as Descendant
 
 
 {-| Note: the selectors are stored in reverse order for better prepending perf.
@@ -401,6 +402,49 @@ queryErrorToString query error =
                 ++ " instead.\n\n\nHINT: If you actually expected "
                 ++ toString resultCount
                 ++ " elements, use Query.findAll instead of Query.find."
+
+
+contains : List (ElmHtml msg) -> Query msg -> Expectation
+contains expectedDescendants query =
+    case traverse query of
+        Ok elmHtmlList ->
+            let
+                missing =
+                    missingDescendants elmHtmlList expectedDescendants
+
+                prettyPrint missingDescendants =
+                    String.join
+                        "\n\n---------------------------------------------\n\n"
+                        (List.indexedMap
+                            (\index descendant -> printIndented 3 index descendant)
+                            missingDescendants
+                        )
+            in
+                if List.isEmpty missing then
+                    Expect.pass
+                else
+                    Expect.fail
+                        (String.join ""
+                            [ "\t✗ /"
+                            , toString <| List.length missing
+                            , "\\ missing descendants: \n\n"
+                            , prettyPrint missing
+                            ]
+                        )
+
+        Err error ->
+            Expect.fail (queryErrorToString query error)
+
+
+missingDescendants : List (ElmHtml msg) -> List (ElmHtml msg) -> List (ElmHtml msg)
+missingDescendants elmHtmlList expected =
+    let
+        isMissing =
+            \expectedDescendant ->
+                not <| Descendant.isDescendant elmHtmlList expectedDescendant
+    in
+            List.filter isMissing expected
+
 
 
 has : List Selector -> Query msg -> Expectation

--- a/tests/Descendant.elm
+++ b/tests/Descendant.elm
@@ -1,0 +1,89 @@
+module Descendant exposing (..)
+
+import Html exposing (Html)
+import Test exposing (..)
+import ElmHtml.InternalTypes exposing (ElmHtml(..))
+import Expect
+import Html exposing (..)
+import Html.Inert exposing (fromHtml, toElmHtml)
+import Test.Html.Query as Query exposing (Single)
+import Test.Html.Descendant exposing (isDescendant)
+
+
+wrapper : Html msg -> Html msg -> Bool
+wrapper html potentialDescendant =
+    let
+        elmHtml =
+            [ htmlToElm html ]
+
+        potentialDescendantElmHtml =
+            htmlToElm potentialDescendant
+    in
+        isDescendant elmHtml potentialDescendantElmHtml
+
+
+all : Test
+all =
+    describe "Contains assertion"
+        [ test "returns true if it contains the expected html once" <|
+            \() ->
+                let
+                    aSingleDescendant =
+                        someTitle "foo"
+
+                    html =
+                        div [] [ aSingleDescendant ]
+                in
+                    wrapper html aSingleDescendant
+                        |> Expect.true ""
+        , test "returns true if it contains the expected html more than once" <|
+            \() ->
+                let
+                    aMultiInstanceDescendant =
+                        someTitle "foo"
+
+                    html =
+                        div []
+                            [ aMultiInstanceDescendant
+                            , aMultiInstanceDescendant
+                            ]
+                in
+                    wrapper html aMultiInstanceDescendant
+                        |> Expect.true ""
+        , test "return true if the node is a nested descendant" <|
+            \() ->
+                let
+                    aNestedDescendant =
+                        someTitle "foo"
+
+                    html =
+                        div []
+                            [ div []
+                                [ div [] [ aNestedDescendant ]
+                                ]
+                            ]
+                in
+                    wrapper html aNestedDescendant
+                        |> Expect.true ""
+        , test "returns false if it does not contain the node" <|
+            \() ->
+                let
+                    notInHtml =
+                        img [] []
+
+                    html =
+                        div [] [ someTitle "foo" ]
+                in
+                    wrapper html notInHtml
+                        |> Expect.false ""
+        ]
+
+
+someTitle : String -> Html msg
+someTitle str =
+    h1 [] [ text str ]
+
+
+htmlToElm : Html msg -> ElmHtml msg
+htmlToElm =
+    toElmHtml << fromHtml

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -6,6 +6,7 @@ import Json.Encode exposing (Value)
 import TestExample
 import Queries
 import Events
+import Descendant
 
 
 main : TestProgram
@@ -13,6 +14,7 @@ main =
     [ TestExample.all
     , Queries.all
     , Events.all
+    , Descendant.all
     ]
         |> Test.concat
         |> run emit

--- a/tests/Queries.elm
+++ b/tests/Queries.elm
@@ -45,6 +45,10 @@ testRoot output =
                 \() ->
                     output
                         |> Query.has [ classes [ "root" ] ]
+            , test "recognizes if is has a specific descendant" <|
+                \() ->
+                    output
+                        |> Query.contains [ someView "Such a title !" ]
             ]
         ]
 
@@ -71,6 +75,11 @@ testFind output =
                     output
                         |> Query.find []
                         |> Query.has [ classes [ "container" ] ]
+            , test "recognizes if is has a specific descendant" <|
+                \() ->
+                    output
+                        |> Query.find []
+                        |> Query.contains [ someView "Such a title !" ]
             ]
         ]
 
@@ -206,6 +215,7 @@ sampleHtml =
                 , a [ href "http://elm-lang.org/examples" ] [ Html.text "examples" ]
                 , a [ href "http://elm-lang.org/docs" ] [ Html.text "docs" ]
                 ]
+            , someView "Such a title !"
             , section [ Attr.class "funky themed", Attr.id "section" ]
                 [ ul [ Attr.class "some-list" ]
                     [ li [ Attr.class "list-item themed" ] [ Html.text "first item" ]
@@ -230,6 +240,7 @@ sampleLazyHtml =
                 , Lazy.lazy (\str -> a [ href "http://elm-lang.org/examples" ] [ Html.text str ]) "examples"
                 , Lazy.lazy (\str -> a [ href "http://elm-lang.org/docs" ] [ Html.text str ]) "docs"
                 ]
+            , someView "Such a title !"
             , section [ Attr.class "funky themed", Attr.id "section" ]
                 [ ul [ Attr.class "some-list" ]
                     [ Lazy.lazy (\str -> li [ Attr.class "list-item themed" ] [ Html.text str ]) "first item"
@@ -243,3 +254,8 @@ sampleLazyHtml =
             , footer [] [ Lazy.lazy2 (\a b -> Html.text <| a ++ b) "this is " "the footer" ]
             ]
         ]
+
+
+someView : String -> Html msg
+someView str =
+    Html.h1 [] [ Html.text str ]


### PR DESCRIPTION
The goal is to be able to check if a function `f` returns the returned `Html Msg` of another function `g` without knowing the details of `g`.

``` elm
test "recognizes if it is has a specific descendant" <|
    \() ->
        let
            aSpecificView data = ... -- some html rendering
            someData = ...
        in
            div [] [ aSpecificView data ]
                |> Query.contains (aSpecificView data)
```

This is just a silly example but let's imagine a more complex view function with conditions to see why this is useful :)