### PR TITLE
Do not map error message

### DIFF
--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -120,7 +120,6 @@ eventResult (EventNode event (QueryInternal.Single showTrace query)) =
             Ok single ->
                 findEvent eventName single
                     |> Result.andThen (\foundEvent -> decodeString foundEvent jsEvent)
-                    |> Result.mapError (\_ -> "Failed to decode string")
 
 
 rawEvent : Event -> ( String, String )


### PR DESCRIPTION
I don't know why it was mapping messages like this, it was hiding important error messages like:

```
The event dblclick does not exist on the found node
```