### PR TITLE
Fix documentation using the wrong event expectation module

### DIFF
--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -58,7 +58,7 @@ type Event
             Html.input [ onInput Change ] [ ]
                 |> Query.fromHtml
                 |> Events.simulate (Input "cats")
-                |> Expect.expectEvent (Change "cats")
+                |> Events.expectEvent (Change "cats")
 
 -}
 simulate : Event -> Query.Single msg -> EventNode msg
@@ -76,7 +76,7 @@ simulate event single =
             Html.input [ onInput Change ] [ ]
                 |> Query.fromHtml
                 |> Events.simulate (Input "cats")
-                |> Expect.expectEvent (Change "cats")
+                |> Events.expectEvent (Change "cats")
 
 -}
 expectEvent : msg -> EventNode msg -> Expectation


### PR DESCRIPTION
The `Expect` module does not expose the `expectEvent` function.