### PR TITLE
Minor cleanup

### DIFF
--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -7,9 +7,7 @@ module Test.Html.Events
         , eventResult
         )
 
-{-|
-
-This module allows you to simulate events on Html nodes, the Msg generated
+{-| This module allows you to simulate events on Html nodes, the Msg generated
 by the event is returned so you can test it
 
 @docs Event, simulate, expectEvent, eventResult

--- a/src/Test/Html/Events.elm
+++ b/src/Test/Html/Events.elm
@@ -92,13 +92,14 @@ expectEvent msg (EventNode event (QueryInternal.Single showTrace query)) =
 
 {-| Returns a Result with the Msg produced by the event simulated on a node
 
-  test "Input produces expected Msg" <|
-      \() ->
-          Html.input [ onInput Change ] [ ]
-              |> Query.fromHtml
-              |> Events.simulate (Input "cats")
-              |> Events.eventResult
-              |> Expect.equal (Ok <| Change "cats")
+    test "Input produces expected Msg" <|
+        \() ->
+            Html.input [ onInput Change ] [ ]
+                |> Query.fromHtml
+                |> Events.simulate (Input "cats")
+                |> Events.eventResult
+                |> Expect.equal (Ok <| Change "cats")
+
 -}
 eventResult : EventNode msg -> Result String msg
 eventResult (EventNode event (QueryInternal.Single showTrace query)) =

--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -14,17 +14,18 @@ module Test.Html.Query
         , each
         )
 
-{-|
+{-| @docs Single, Multiple, fromHtml
 
-@docs Single, Multiple, fromHtml
 
 ## Querying
 
 @docs find, findAll, children, first, index
 
+
 ## Expecting
 
 @docs count, has, hasNot, each
+
 -}
 
 import Html exposing (Html)
@@ -57,6 +58,7 @@ import Expect exposing (Expectation)
 {-| A query that expects to find exactly one element.
 
 Contrast with [`Multiple`](#Multiple).
+
 -}
 type alias Single msg =
     Internal.Single msg
@@ -65,6 +67,7 @@ type alias Single msg =
 {-| A query that may find any number of elements, including zero.
 
 Contrast with [`Single`](#Single).
+
 -}
 type alias Multiple msg =
     Internal.Multiple msg
@@ -84,6 +87,7 @@ typically begin.
             Html.button [] [ Html.text "I'm a button!" ]
                 |> Query.fromHtml
                 |> Query.has [ text "I'm a button!" ]
+
 -}
 fromHtml : Html msg -> Single msg
 fromHtml html =
@@ -117,6 +121,7 @@ fromHtml html =
                 |> Query.fromHtml
                 |> Query.findAll [ tag "li" ]
                 |> Query.count (Expect.equal 3)
+
 -}
 findAll : List Selector -> Single msg -> Multiple msg
 findAll selectors (Internal.Single showTrace query) =
@@ -147,6 +152,7 @@ findAll selectors (Internal.Single showTrace query) =
                 |> Query.find [ tag "ul" ]
                 |> Query.children []
                 |> Query.each (Query.has [ tag "li" ])
+
 -}
 children : List Selector -> Single msg -> Multiple msg
 children selectors (Internal.Single showTrace query) =
@@ -177,6 +183,7 @@ If no descendants match, or if more than one matches, the test will fail.
                 |> Query.fromHtml
                 |> Query.find [ tag "ul" ]
                 |> Query.has [ classes [ "items", "active" ] ]
+
 -}
 find : List Selector -> Single msg -> Single msg
 find selectors (Internal.Single showTrace query) =
@@ -210,6 +217,7 @@ will fail.
                 |> Query.findAll [ tag "li" ]
                 |> Query.first
                 |> Query.has [ text "first item" ]
+
 -}
 first : Multiple msg -> Single msg
 first (Internal.Multiple showTrace query) =
@@ -247,6 +255,7 @@ If the index falls outside the bounds of the match, the test will fail.
                 |> Query.findAll [ tag "li" ]
                 |> Query.index 1
                 |> Query.has [ text "second item" ]
+
 -}
 index : Int -> Multiple msg -> Single msg
 index position (Internal.Multiple showTrace query) =
@@ -280,6 +289,7 @@ index position (Internal.Multiple showTrace query) =
                 |> Query.fromHtml
                 |> Query.findAll [ tag "li" ]
                 |> Query.count (Expect.equal 3)
+
 -}
 count : (Int -> Expectation) -> Multiple msg -> Expectation
 count expect ((Internal.Multiple showTrace query) as multiple) =
@@ -308,6 +318,7 @@ count expect ((Internal.Multiple showTrace query) as multiple) =
                 |> Query.fromHtml
                 |> Query.find [ tag "ul" ]
                 |> Query.has [ tag "ul", classes [ "items", "active" ] ]
+
 -}
 has : List Selector -> Single msg -> Expectation
 has selectors (Internal.Single showTrace query) =
@@ -330,6 +341,7 @@ has selectors (Internal.Single showTrace query) =
                 |> Query.fromHtml
                 |> Query.find [ tag "div" ]
                 |> Query.hasNot [ tag "div", class "progress-bar" ]
+
 -}
 hasNot : List Selector -> Single msg -> Expectation
 hasNot selectors (Internal.Single showTrace query) =
@@ -366,6 +378,7 @@ hasNot selectors (Internal.Single showTrace query) =
                     [ Query.has [ tag "ul" ]
                     , Query.has [ classes [ "items", "active" ] ]
                     ]
+
 -}
 each : (Single msg -> Expectation) -> Multiple msg -> Expectation
 each check (Internal.Multiple showTrace query) =

--- a/src/Test/Html/Query/Internal.elm
+++ b/src/Test/Html/Query/Internal.elm
@@ -28,6 +28,7 @@ the beginning of the error message.
 We need to track this so that Query.each can turn it off. Otherwise you get
 fromHtml printed twice - once at the very top, then again for the nested
 expectation that Query.each delegated to.
+
 -}
 type Single msg
     = Single Bool (Query msg)
@@ -218,13 +219,14 @@ prependSelector (Query node selectors) selector =
 {-| This is a more efficient implementation of the following:
 
 list
-    |> Array.fromList
-    |> Array.get index
-    |> Maybe.map (\elem -> [ elem ])
-    |> Maybe.withDefault []
+|> Array.fromList
+|> Array.get index
+|> Maybe.map (\elem -> [ elem ])
+|> Maybe.withDefault []
 
 It also supports wraparound via negative indeces, e.g. passing -1 for an index
 gets you the last element.
+
 -}
 getElementAt : Int -> List a -> List a
 getElementAt index list =

--- a/src/Test/Html/Selector.elm
+++ b/src/Test/Html/Selector.elm
@@ -15,16 +15,18 @@ module Test.Html.Selector
         , disabled
         )
 
-{-|
-@docs Selector
+{-| @docs Selector
+
 
 ## General Selectors
 
 @docs tag, text, attribute, boolAttribute, all
 
+
 ## Attributes
 
 @docs id, class, classes, className, checked, selected, disabled
+
 -}
 
 import Test.Html.Selector.Internal as Internal exposing (..)
@@ -55,6 +57,7 @@ type alias Selector =
             Html.button [ Attr.class "btn btn-large" ] [ Html.text "Reply" ]
                 |> Query.fromHtml
                 |> Query.has [ replyBtnSelector ]
+
 -}
 all : List Selector -> Selector
 all =
@@ -80,6 +83,7 @@ To match the element's exact class attribute string, use [`className`](#classNam
             Html.button [ Attr.class "btn btn-large" ] [ Html.text "Reply" ]
                 |> Query.fromHtml
                 |> Query.has [ classes [ "btn", "btn-large" ] ]
+
 -}
 classes : List String -> Selector
 classes =
@@ -104,6 +108,7 @@ To match the element's exact class attribute string, use [`className`](#classNam
             Html.button [ Attr.class "btn btn-large" ] [ Html.text "Reply" ]
                 |> Query.fromHtml
                 |> Query.has [ class "btn-large" ]
+
 -}
 class : String -> Selector
 class =
@@ -128,6 +133,7 @@ attribute exactly.
             Html.button [ Attr.class "btn btn-large" ] [ Html.text "Reply" ]
                 |> Query.fromHtml
                 |> Query.has [ className "btn btn-large" ]
+
 -}
 className : String -> Selector
 className =
@@ -150,6 +156,7 @@ className =
                 |> Query.fromHtml
                 |> Query.find [ id "welcome" ]
                 |> Query.has [ text "Hello!" ]
+
 -}
 id : String -> Selector
 id =
@@ -172,6 +179,7 @@ id =
                 |> Query.fromHtml
                 |> Query.find [ tag "h1" ]
                 |> Query.has [ text "Hello!" ]
+
 -}
 tag : String -> Selector
 tag name =
@@ -199,6 +207,7 @@ For attributes with boolean values, such as `checked`, use [`boolAttribute`](#bo
                 |> Query.fromHtml
                 |> Query.find [ attribute "title" "greeting" ]
                 |> Query.has [ text "Hello!" ]
+
 -}
 attribute : String -> String -> Selector
 attribute name value =
@@ -227,6 +236,7 @@ For attributes with string values, such as `title`, use [`attribute`](#attribute
                 |> Query.fromHtml
                 |> Query.find [ boolAttribute "disabled" True ]
                 |> Query.has [ text "Reply" ]
+
 -}
 boolAttribute : String -> Bool -> Selector
 boolAttribute name value =


### PR DESCRIPTION
Run `elm-format` and fix an indentation issue in docs. (Code block wasn't indented enough to trigger that formatting in Markdown.