### PR TITLE
Event API Revisions

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -9,7 +9,7 @@
     "exposed-modules": [
         "Test.Html.Selector",
         "Test.Html.Query",
-        "Test.Html.Events"
+        "Test.Html.Event"
     ],
     "native-modules": true,
     "dependencies": {

--- a/examples/FailingTests.elm
+++ b/examples/FailingTests.elm
@@ -4,7 +4,7 @@ import ExampleApp exposing (Msg(..), exampleModel, view)
 import Expect
 import Json.Encode exposing (Value)
 import Test exposing (..)
-import Test.Html.Events as Events exposing (Event(..))
+import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
 import Test.Runner.Node exposing (TestProgram, run)

--- a/src/Test/Html/Event.elm
+++ b/src/Test/Html/Event.elm
@@ -36,8 +36,8 @@ they result in certain `Msg` values being sent to `update`.
 
 import Dict
 import ElmHtml.InternalTypes exposing (ElmHtml, ElmHtml(..), Tagger)
-import Json.Decode as Decode exposing (Value, Decoder)
-import Json.Encode as Encode
+import Json.Decode as Decode exposing (Decoder)
+import Json.Encode as Encode exposing (Value)
 import Test.Html.Query as Query
 import Test.Html.Query.Internal as QueryInternal
 import Expect exposing (Expectation)

--- a/src/Test/Html/Event.elm
+++ b/src/Test/Html/Event.elm
@@ -1,4 +1,4 @@
-module Test.Html.Events
+module Test.Html.Event
     exposing
         ( Event(..)
         , EventNode
@@ -60,8 +60,8 @@ type Event
         \() ->
             Html.input [ onInput Change ] [ ]
                 |> Query.fromHtml
-                |> Events.simulate (Input "cats")
-                |> Events.expectEvent (Change "cats")
+                |> Event.simulate (Input "cats")
+                |> Event.expectEvent (Change "cats")
 
 -}
 simulate : Event -> Query.Single msg -> EventNode msg
@@ -78,8 +78,8 @@ simulate event single =
         \() ->
             Html.input [ onInput Change ] [ ]
                 |> Query.fromHtml
-                |> Events.simulate (Input "cats")
-                |> Events.expectEvent (Change "cats")
+                |> Event.simulate (Input "cats")
+                |> Event.expectEvent (Change "cats")
 
 -}
 expectEvent : msg -> EventNode msg -> Expectation
@@ -101,8 +101,8 @@ expectEvent msg (EventNode event (QueryInternal.Single showTrace query)) =
         \() ->
             Html.input [ onInput Change ] [ ]
                 |> Query.fromHtml
-                |> Events.simulate (Input "cats")
-                |> Events.eventResult
+                |> Event.simulate (Input "cats")
+                |> Event.eventResult
                 |> Expect.equal (Ok <| Change "cats")
 
 -}
@@ -195,7 +195,7 @@ findEvent eventName element =
         eventDecoder node =
             node.facts.events
                 |> Dict.get eventName
-                |> Result.fromMaybe ("Events.expectEvent: The event \x1B[32m" ++ eventName ++ "\x1B[39m does not exist on the found node.\n\n" ++ elementOutput)
+                |> Result.fromMaybe ("Event.expectEvent: The event \x1B[32m" ++ eventName ++ "\x1B[39m does not exist on the found node.\n\n" ++ elementOutput)
     in
         case element of
             TextTag _ ->

--- a/src/Test/Html/Event.elm
+++ b/src/Test/Html/Event.elm
@@ -67,6 +67,33 @@ type Event msg
                 |> Event.simulate (Event.input "cats")
                 |> Event.expect (Change "cats")
 
+You can simulate custom events by passing a tuple containing the event name string and a
+`Value` representing the event object the browser would send to the event listener callback.
+
+    import Test.Html.Event as Event
+    import Json.Encode as Encode exposing (Value)
+
+
+    type Msg
+        = Change String
+
+
+    test "Input produces expected Msg" <|
+        \() ->
+            let
+                simulatedEventObject : Value
+                simulatedEventObject =
+                    Encode.object
+                        [ ( "target"
+                          , Encode.object [ ( "value", Encode.string "cats" ) ]
+                          )
+                        ]
+            in
+                Html.input [ onInput Change ] [ ]
+                    |> Query.fromHtml
+                    |> Event.simulate ( "input", simulatedEventObject )
+                    |> Event.expect (Change "cats")
+
 -}
 simulate : ( String, Value ) -> Query.Single msg -> Event msg
 simulate =

--- a/src/Test/Html/Event.elm
+++ b/src/Test/Html/Event.elm
@@ -195,7 +195,7 @@ findEvent eventName element =
         eventDecoder node =
             node.facts.events
                 |> Dict.get eventName
-                |> Result.fromMaybe ("Event.expectEvent: The event \x1B[32m" ++ eventName ++ "\x1B[39m does not exist on the found node.\n\n" ++ elementOutput)
+                |> Result.fromMaybe ("Event.expectEvent: The event " ++ eventName ++ " does not exist on the found node.\n\n" ++ elementOutput)
     in
         case element of
             TextTag _ ->

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -5,7 +5,7 @@ import Html exposing (Html, button, div, input, text)
 import Html.Attributes as Attr exposing (href)
 import Html.Events exposing (..)
 import Html.Lazy as Lazy
-import Json.Decode
+import Json.Decode exposing (Value)
 import Json.Encode as Encode
 import Test exposing (..)
 import Test.Html.Event as Event exposing (Event)
@@ -60,7 +60,7 @@ all =
             \() ->
                 input [ on "keyup" (Json.Decode.map SampleKeyUpMsg keyCode) ] []
                     |> Query.fromHtml
-                    |> Event.simulate "keyup" (Encode.object [ ( "keyCode", Encode.int 5 ) ])
+                    |> Event.simulate ( "keyup", Encode.object [ ( "keyCode", Encode.int 5 ) ] )
                     |> Event.expect (SampleKeyUpMsg 5)
         , testEvent onDoubleClick Event.doubleClick
         , testEvent onMouseDown Event.mouseDown
@@ -127,9 +127,9 @@ deepMappedHtml =
         ]
 
 
-testEvent : (Msg -> Html.Attribute Msg) -> Event -> Test
-testEvent testOn event =
-    test ("returns msg for " ++ (toString event) ++ " event") <|
+testEvent : (Msg -> Html.Attribute Msg) -> ( String, Value ) -> Test
+testEvent testOn (( eventName, eventValue ) as event) =
+    test ("returns msg for " ++ eventName ++ "(" ++ toString eventValue ++ ") event") <|
         \() ->
             input [ testOn SampleMsg ] []
                 |> Query.fromHtml

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -6,8 +6,9 @@ import Html.Attributes as Attr exposing (href)
 import Html.Events exposing (..)
 import Html.Lazy as Lazy
 import Json.Decode
+import Json.Encode as Encode
 import Test exposing (..)
-import Test.Html.Events as Events exposing (Event(..))
+import Test.Html.Event as Event exposing (Event)
 import Test.Html.Query as Query exposing (Single)
 import Test.Html.Selector exposing (tag)
 
@@ -20,62 +21,62 @@ all =
                 Query.fromHtml sampleHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.simulate Click
-                    |> Events.expectEvent SampleMsg
+                    |> Event.simulate Event.click
+                    |> Event.expect SampleMsg
         , test "returns msg for click on lazy html" <|
             \() ->
                 Query.fromHtml sampleLazyHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.simulate Click
-                    |> Events.expectEvent SampleMsg
+                    |> Event.simulate Event.click
+                    |> Event.expect SampleMsg
         , test "returns msg for click on mapped html" <|
             \() ->
                 Query.fromHtml sampleMappedHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
-                    |> Events.simulate Click
-                    |> Events.expectEvent MappedSampleMsg
+                    |> Event.simulate Event.click
+                    |> Event.expect MappedSampleMsg
         , test "returns msg for click on deep mapped html" <|
             \() ->
                 Query.fromHtml deepMappedHtml
                     |> Query.findAll [ tag "input" ]
                     |> Query.first
-                    |> Events.simulate (Input "foo")
-                    |> Events.expectEvent (SampleInputMsg "foobar")
+                    |> Event.simulate (Event.input "foo")
+                    |> Event.expect (SampleInputMsg "foobar")
         , test "returns msg for input with transformation" <|
             \() ->
                 input [ onInput (String.toUpper >> SampleInputMsg) ] []
                     |> Query.fromHtml
-                    |> Events.simulate (Input "cats")
-                    |> Events.expectEvent (SampleInputMsg "CATS")
+                    |> Event.simulate (Event.input "cats")
+                    |> Event.expect (SampleInputMsg "CATS")
         , test "returns msg for check event" <|
             \() ->
                 input [ onCheck SampleCheckedMsg ] []
                     |> Query.fromHtml
-                    |> Events.simulate (Check True)
-                    |> Events.expectEvent (SampleCheckedMsg True)
+                    |> Event.simulate (Event.check True)
+                    |> Event.expect (SampleCheckedMsg True)
         , test "returns msg for custom event" <|
             \() ->
                 input [ on "keyup" (Json.Decode.map SampleKeyUpMsg keyCode) ] []
                     |> Query.fromHtml
-                    |> Events.simulate (CustomEvent "keyup" "{\"keyCode\": 5}")
-                    |> Events.expectEvent (SampleKeyUpMsg 5)
-        , testEvent onDoubleClick DoubleClick
-        , testEvent onMouseDown MouseDown
-        , testEvent onMouseUp MouseUp
-        , testEvent onMouseLeave MouseLeave
-        , testEvent onMouseOver MouseOver
-        , testEvent onMouseOut MouseOut
-        , testEvent onSubmit Submit
-        , testEvent onBlur Blur
-        , testEvent onFocus Focus
+                    |> Event.simulate "keyup" (Encode.object [ ( "keyCode", Encode.int 5 ) ])
+                    |> Event.expect (SampleKeyUpMsg 5)
+        , testEvent onDoubleClick Event.doubleClick
+        , testEvent onMouseDown Event.mouseDown
+        , testEvent onMouseUp Event.mouseUp
+        , testEvent onMouseLeave Event.mouseLeave
+        , testEvent onMouseOver Event.mouseOver
+        , testEvent onMouseOut Event.mouseOut
+        , testEvent onSubmit Event.submit
+        , testEvent onBlur Event.blur
+        , testEvent onFocus Event.focus
         , test "event result" <|
             \() ->
                 Query.fromHtml sampleHtml
                     |> Query.find [ tag "button" ]
-                    |> Events.simulate Click
-                    |> Events.eventResult
+                    |> Event.simulate Event.click
+                    |> Event.toResult
                     |> Expect.equal (Ok SampleMsg)
         ]
 
@@ -132,5 +133,5 @@ testEvent testOn event =
         \() ->
             input [ testOn SampleMsg ] []
                 |> Query.fromHtml
-                |> Events.simulate event
-                |> Events.expectEvent SampleMsg
+                |> Event.simulate event
+                |> Event.expect SampleMsg


### PR DESCRIPTION
Having spent some time with @rogeriochaves's awesome event triggering system, I have some ideas for how to revise the API:

### Current API

```elm
test "input produces expected Msg" <|
    \() ->
        Html.input [ onInput Change ] [ ]
            |> Query.fromHtml
            |> Events.simulate (Input "cats")
            |> Events.expectEvent (Change "cats")
```

### Proposed Change

```elm
test "input produces expected Msg" <|
    \() ->
        Html.input [ onInput Change ] [ ]
            |> Query.fromHtml
            |> Event.simulate (Event.input "cats")
            |> Event.expect (Change "cats")
```

The big change is making (lowercase) functions rather than (uppercase) union type constructors for the events.

Before:

```elm
|> Events.simulate (Input "cats")
|> Events.expectEvent (Change "cats")
```

After:

```elm
|> Event.simulate (Event.input "cats")
|> Event.expect (Change "cats")
```

This has a few benefits.

1. It's easier to tell at a glance which is the `Msg` (the uppercase `Change`) and which is the event (the lowercase `input "cats"` - as opposed to the previous `Input "cats"`).
2. Each event helper can have its own documentation, which is especially helpful in the case of nontrivial ones like `check`.
3. Adding new helpers can be a minor version bump.

Other changes include:

* Renamed `EventNode` to `Event` and made the old `Event` a `( String, Value )` tuple. We never treat these as anything other than function arguments that get passed around without modification, so giving them their own type doesn't seem warranted.
* The module is called `Event` instead of `Events` - this makes `Event.input` read nicely ("an `input` event") and makes the module name correspond to the type - the `Event` module and the `Event` type, like the `Maybe` module and the `Maybe` type.
* Instead of `Events.eventResult` we can have the self-explanatory `Event.toResult` - which takes an `Event` and returns a `Result`!
* In a similar vein, renaming `Events.expectEvent` to `Event.expect` - which takes an `Event` (and a `Msg`) and returns an `Expectation`.
* Removing the formatting characters from the error message - those won't look great in a browser. 😉

Thoughts?