### PR TITLE
proposal filterMap

### DIFF
--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -6,7 +6,6 @@ module Test.Html.Query
         , contains
         , count
         , each
-        , filterMap
         , find
         , findAll
         , first
@@ -14,6 +13,7 @@ module Test.Html.Query
         , has
         , hasNot
         , index
+        , keep
         )
 
 {-| Querying HTML structure.
@@ -23,7 +23,7 @@ module Test.Html.Query
 
 ## Querying
 
-@docs find, findAll, children, first, index
+@docs find, findAll, children, first, index, keep
 
 
 ## Expecting
@@ -157,16 +157,16 @@ findAll selectors (Internal.Single showTrace query) =
                 ]
                 |> Query.fromHtml
                 |> Query.findAll [ tag "li" ]
-                |> Query.filterMap [ tag "a" ]
+                |> Query.keep ( tag "a" )
                 |> Expect.all
                     [ Query.each (Query.has [ tag "a" ])
                     , Query.first >> Query.has [ text "first item" ]
                     ]
 
 -}
-filterMap : List Selector -> Multiple msg -> Multiple msg
-filterMap selectors (Internal.Multiple showTrace query) =
-    Internal.FindAll selectors
+keep : Selector -> Multiple msg -> Multiple msg
+keep selector (Internal.Multiple showTrace query) =
+    Internal.FindAll [ selector ]
         |> Internal.prependSelector query
         |> Internal.Multiple showTrace
 

--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -1,18 +1,19 @@
 module Test.Html.Query
     exposing
-        ( Single
-        , Multiple
-        , fromHtml
+        ( Multiple
+        , Single
+        , children
+        , contains
+        , count
+        , each
+        , filterMap
         , find
         , findAll
-        , children
         , first
-        , index
-        , count
-        , contains
+        , fromHtml
         , has
         , hasNot
-        , each
+        , index
         )
 
 {-| Querying HTML structure.
@@ -31,12 +32,12 @@ module Test.Html.Query
 
 -}
 
-import Html exposing (Html)
-import Test.Html.Selector.Internal as Selector exposing (Selector, selectorToString)
-import Test.Html.Query.Internal as Internal exposing (QueryError(..), failWithQuery)
-import Html.Inert as Inert
-import Expect exposing (Expectation)
 import ElmHtml.InternalTypes exposing (ElmHtml)
+import Expect exposing (Expectation)
+import Html exposing (Html)
+import Html.Inert as Inert
+import Test.Html.Query.Internal as Internal exposing (QueryError(..), failWithQuery)
+import Test.Html.Selector.Internal as Selector exposing (Selector, selectorToString)
 
 
 {- DESIGN NOTES:
@@ -129,6 +130,42 @@ fromHtml html =
 -}
 findAll : List Selector -> Single msg -> Multiple msg
 findAll selectors (Internal.Single showTrace query) =
+    Internal.FindAll selectors
+        |> Internal.prependSelector query
+        |> Internal.Multiple showTrace
+
+
+{-| Find the descendant elements of the result of `findAll` which match all the given selectors.
+
+    import Html exposing (div, ul, li)
+    import Html.Attributes exposing (class)
+    import Test.Html.Query as Query
+    import Test exposing (test)
+    import Test.Html.Selector exposing (tag)
+    import Expect
+
+
+    test "The list has three items" <|
+        \() ->
+            div []
+                [ ul [ class "items active" ]
+                    [ li [] [ a [] [ text "first item" ]]
+                    , li [] [ a [] [ text "second item" ]]
+                    , li [] [ a [] [ text "third item" ]]
+                    , li [] [ button [] [ text "button" ]]
+                    ]
+                ]
+                |> Query.fromHtml
+                |> Query.findAll [ tag "li" ]
+                |> Query.filterMap [ tag "a" ]
+                |> Expect.all
+                    [ Query.each (Query.has [ tag "a" ])
+                    , Query.first >> Query.has [ text "first item" ]
+                    ]
+
+-}
+filterMap : List Selector -> Multiple msg -> Multiple msg
+filterMap selectors (Internal.Multiple showTrace query) =
     Internal.FindAll selectors
         |> Internal.prependSelector query
         |> Internal.Multiple showTrace
@@ -334,17 +371,15 @@ contains expectedHtml (Internal.Single showTrace query) =
         expectedElmHtml =
             List.map htmlToElm expectedHtml
     in
-        Internal.contains
-            expectedElmHtml
-            query
-            |> failWithQuery showTrace "Query.contains" query
+    Internal.contains
+        expectedElmHtml
+        query
+        |> failWithQuery showTrace "Query.contains" query
 
 
 htmlToElm : Html msg -> ElmHtml msg
 htmlToElm =
     Inert.fromHtml >> Inert.toElmHtml
-
-
 
 
 {-| Expect the element to match all of the given selectors.
@@ -399,8 +434,8 @@ hasNot selectors (Internal.Single showTrace query) =
         queryName =
             "Query.hasNot " ++ Internal.joinAsList selectorToString selectors
     in
-        Internal.hasNot selectors query
-            |> failWithQuery showTrace queryName query
+    Internal.hasNot selectors query
+        |> failWithQuery showTrace queryName query
 
 
 {-| Expect that a [`Single`](#Single) expectation will hold true for each of the

--- a/tests/Queries.elm
+++ b/tests/Queries.elm
@@ -24,7 +24,7 @@ lazyTests =
 testers : List (Single msg -> Test)
 testers =
     [ testFindAll
-    , testFilterMap
+    , testKeep
     , testFind
     , testRoot
     , testFirst
@@ -160,31 +160,31 @@ testFindAll output =
         ]
 
 
-testFilterMap : Single msg -> Test
-testFilterMap output =
-    describe "Query.filterMap"
-        [ test "filter and map the result of findAll" <|
+testKeep : Single msg -> Test
+testKeep output =
+    describe "Query.keep"
+        [ test "only keep a subsect of a result" <|
             \() ->
                 output
                     |> Query.findAll [ tag "section" ]
-                    |> Query.filterMap [ tag "ul" ]
-                    |> Query.filterMap [ class "list-item" ]
+                    |> Query.keep (tag "ul")
+                    |> Query.keep (class "list-item")
                     |> Expect.all
                         [ Query.each (Query.has [ tag "li" ])
                         , Query.first >> Query.has [ text "first item" ]
                         ]
-        , test "filters in the second section as well" <|
+        , test "keep from the second section as well" <|
             \() ->
                 output
                     |> Query.findAll [ tag "section" ]
-                    |> Query.filterMap [ class "nested-div" ]
+                    |> Query.keep (class "nested-div")
                     |> Query.first
                     |> Query.has [ text "boring section" ]
-        , test "filters elements from both matches" <|
+        , test "keep elements from both matches" <|
             \() ->
                 output
                     |> Query.findAll [ tag "section" ]
-                    |> Query.filterMap [ class "tooltip", class "questions" ]
+                    |> Query.keep (class "tooltip-questions")
                     |> Query.count (Expect.equal 2)
         ]
 
@@ -264,16 +264,16 @@ sampleHtml =
                     , li [ Attr.class "list-item themed" ] [ Html.text "second item" ]
                     , li [ Attr.class "list-item themed selected" ] [ Html.text "third item" ]
                     , li [ Attr.class "list-item themed" ] [ Html.text "fourth item" ]
-                    , span [ Attr.class "tooltip questions" ] [ Html.text "?" ]
+                    , span [ Attr.class "tooltip-questions" ] [ Html.text "?" ]
                     ]
                 ]
             , section []
                 [ div [ Attr.class "nested-div" ] [ Html.text "boring section" ]
-                , span [ Attr.class "tooltip questions" ] [ Html.text "?" ]
+                , span [ Attr.class "tooltip-questions" ] [ Html.text "?" ]
                 ]
             , footer []
                 [ Html.text "this is the footer"
-                , span [ Attr.class "tooltip questions" ] [ Html.text "?" ]
+                , span [ Attr.class "tooltip-questions" ] [ Html.text "?" ]
                 ]
             ]
         ]
@@ -295,13 +295,13 @@ sampleLazyHtml =
                     , Lazy.lazy (\str -> li [ Attr.class "list-item themed" ] [ Html.text str ]) "second item"
                     , Lazy.lazy (\str -> li [ Attr.class "list-item themed selected" ] [ Html.text str ]) "third item"
                     , Lazy.lazy (\str -> li [ Attr.class "list-item themed" ] [ Html.text str ]) "fourth item"
-                    , Lazy.lazy (\str -> span [ Attr.class "tooltip questions" ] [ Html.text str ]) "?"
+                    , Lazy.lazy (\str -> span [ Attr.class "tooltip-questions" ] [ Html.text str ]) "?"
                     ]
                 ]
             , section []
                 [ div [ Attr.class "nested-div" ]
                     [ Html.text "boring section"
-                    , Lazy.lazy (\str -> span [ Attr.class "tooltip questions" ] [ Html.text str ]) "?"
+                    , Lazy.lazy (\str -> span [ Attr.class "tooltip-questions" ] [ Html.text str ]) "?"
                     ]
                 ]
             , footer []


### PR DESCRIPTION
We often have the use-case where we want to findAll elements with a certain class and then narrowing the search result to a specific subset. We use `index` to find the right element, but I think those tests tend to be pretty brittle. I think it's better to narrow the results with an actual selector. I chose `filterMap` as the name for this function, but I'm not super happy with it. I had `findAllIn` before, which I think is worse.

How do you like this?