### PR TITLE
Force thunks under mapped html

### DIFF
--- a/src/Native/HtmlAsJson.js
+++ b/src/Native/HtmlAsJson.js
@@ -6,6 +6,9 @@ var _eeue56$elm_html_test$Native_HtmlAsJson = (function() {
         if (typeof vNode !== 'undefined' && vNode.type === 'thunk' && !vNode.node) {
             vNode.node = vNode.thunk.apply(vNode.thunk, vNode.args);
         }
+        if (typeof vNode !== 'undefined' && vNode.type === 'tagger') {
+            vNode.node = forceThunks(vNode.node);
+        }
         if (typeof vNode !== 'undefined' && typeof vNode.children !== 'undefined') {
             vNode.children = vNode.children.map(forceThunks);
         }

--- a/tests/Events.elm
+++ b/tests/Events.elm
@@ -4,6 +4,7 @@ import Expect
 import Html exposing (Html, button, div, input, text)
 import Html.Attributes as Attr exposing (href)
 import Html.Events exposing (..)
+import Html.Keyed as Keyed
 import Html.Lazy as Lazy
 import Json.Decode exposing (Value)
 import Json.Encode as Encode
@@ -33,6 +34,20 @@ all =
         , test "returns msg for click on mapped html" <|
             \() ->
                 Query.fromHtml sampleMappedHtml
+                    |> Query.findAll [ tag "button" ]
+                    |> Query.first
+                    |> Event.simulate Event.click
+                    |> Event.expect MappedSampleMsg
+        , test "returns msg for click on mapped lazy html" <|
+            \() ->
+                Query.fromHtml sampleMappedLazyHtml
+                    |> Query.findAll [ tag "button" ]
+                    |> Query.first
+                    |> Event.simulate Event.click
+                    |> Event.expect MappedSampleMsg
+        , test "returns msg for click on mapped keyed html" <|
+            \() ->
+                Query.fromHtml sampleMappedKeyedHtml
                     |> Query.findAll [ tag "button" ]
                     |> Query.first
                     |> Event.simulate Event.click
@@ -112,10 +127,30 @@ sampleMappedHtml =
         ]
 
 
+sampleMappedLazyHtml : Html Msg
+sampleMappedLazyHtml =
+    div [ Attr.class "container" ]
+        [ Html.map (always MappedSampleMsg) <|
+            Lazy.lazy
+                (\str -> button [ onClick SampleMsg ] [ text str ])
+                "click me"
+        ]
+
+
+sampleMappedKeyedHtml : Html Msg
+sampleMappedKeyedHtml =
+    div [ Attr.class "container" ]
+        [ Html.map (always MappedSampleMsg) <|
+            Keyed.node "button"
+                [ onClick SampleMsg ]
+                [ ( "key", text "click me" ) ]
+        ]
+
+
 deepMappedHtml : Html Msg
 deepMappedHtml =
     div []
-        [ Html.map (SampleInputMsg)
+        [ Html.map SampleInputMsg
             (div []
                 [ Html.map (\msg -> msg ++ "bar")
                     (div []


### PR DESCRIPTION
Before this, a runtime error would be raised when using lazy under a mapped HTML. The reason is that thunks under mapped nodes were not evaluated so they made it through to the decoder.

This fixes  this so that we force thunks under any mapped node we see.

Paired with @stoeffel on this.