### PR TITLE
index: don't wrap around

### DIFF
--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -271,7 +271,7 @@ first (Internal.Multiple showTrace query) =
 `Query.index 0` would match the first element, and `Query.index 1` would match
 the second element.
 
-You can pass negative numbers to "wrap around" - for example, `Query.index -1`
+You can pass negative numbers to get elements from the end - for example, `Query.index -1`
 will match the last element, and `Query.index -2` will match the second-to-last.
 
 If the index falls outside the bounds of the match, the test will fail.

--- a/src/Test/Html/Query/Internal.elm
+++ b/src/Test/Html/Query/Internal.elm
@@ -227,7 +227,7 @@ list
 |> Maybe.map (\elem -> [ elem ])
 |> Maybe.withDefault []
 
-It also supports wraparound via negative indeces, e.g. passing -1 for an index
+It also supports negative indeces, e.g. passing -1 for an index
 gets you the last element.
 
 -}
@@ -237,8 +237,14 @@ getElementAt index list =
         length =
             List.length list
     in
-    -- Avoid attempting % 0
-    if length == 0 then
+    if
+        -- Avoid attempting % 0
+        (length == 0)
+            -- don't wrap around if index is too high
+            || (index >= length)
+            -- don't wrap around if index is too low
+            || (index < 0 && abs index > length)
+    then
         []
     else
         -- Support wraparound, e.g. passing -1 to get the last element.

--- a/tests/Queries.elm
+++ b/tests/Queries.elm
@@ -206,21 +206,81 @@ testFirst output =
 testIndex : Single msg -> Test
 testIndex output =
     describe "Query.index"
-        [ describe "Query.index 0" <|
-            [ test "sees it's a <div class='container'>" <|
-                \() ->
-                    output
-                        |> Query.findAll []
-                        |> Query.index 0
-                        |> Query.has [ tag "div", class "container" ]
-            ]
-        , describe "Query.index -1" <|
-            [ test "sees it's a <div class='container'>" <|
+        [ describe "only 1 element"
+            [ test "index -1 matches" <|
                 \() ->
                     output
                         |> Query.findAll []
                         |> Query.index -1
                         |> Query.has [ tag "div", class "container" ]
+            , test "index 0 matches" <|
+                \() ->
+                    output
+                        |> Query.findAll []
+                        |> Query.index 0
+                        |> Query.has [ tag "div", class "container" ]
+            , test "index -2 too low" <|
+                \() ->
+                    output
+                        |> Query.findAll []
+                        |> Query.index -2
+                        |> Query.hasNot [ tag "div" ]
+            , test "index 1 too high" <|
+                \() ->
+                    output
+                        |> Query.findAll []
+                        |> Query.index 1
+                        |> Query.hasNot [ tag "div" ]
+            ]
+        , describe "3 element"
+            [ test "index 0 matches" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.index 0
+                        |> Query.has [ tag "a", text "home" ]
+            , test "index 1 matches" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.index 1
+                        |> Query.has [ tag "a", text "examples" ]
+            , test "index 2 matches" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.index 2
+                        |> Query.has [ tag "a", text "docs" ]
+            , test "index -3 matches" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.index -3
+                        |> Query.has [ tag "a", text "home" ]
+            , test "index -2 matches" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.index -2
+                        |> Query.has [ tag "a", text "examples" ]
+            , test "index -1 matches" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.index -1
+                        |> Query.has [ tag "a", text "docs" ]
+            , test "index -4  too low" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.index -4
+                        |> Query.hasNot [ tag "a" ]
+            , test "index 3 too high" <|
+                \() ->
+                    output
+                        |> Query.findAll [ tag "a" ]
+                        |> Query.index 3
+                        |> Query.hasNot [ tag "a" ]
             ]
         ]
 


### PR DESCRIPTION
resolves #45 

## What changed?

* don't wrap index around if it's too high or to low.
* adds extensive tests for `index`.