### PR TITLE
adds selector `hasChildWith`

### DIFF
--- a/src/Test/Html/Selector.elm
+++ b/src/Test/Html/Selector.elm
@@ -267,23 +267,30 @@ text =
 
 
 {-| Matches elements that contain children that match the given selectors.
+You will get the element and **not** the child.
+This is useful when you want a sepecific element and continue working with it.
+You can use `Test.Html.Query.contains` if you just want to expect that an element contains some child.
 
     import Html
-    import Html.Attributes as Attr
+    import Html.Events exposing (onClick)
     import Test exposing (test)
+    import Test.Html.Event as Event
     import Test.Html.Query as Query
-    import Test.Html.Selector exposing (class, hasChildWith, tag)
+    import Test.Html.Selector exposing (hasChildWith, tag)
 
     test : Test
     test =
         test "..." <|
             Html.div []
-                [ Html.button [ Attr.class "super-button" ] [ Html.text "click me" ] ]
+                [ Html.button [ onClick NopeMsg ] [ Html.text "not me" ]
+                , Html.button [ onClick ClickedMsg ] [ Html.text "click me" ]
+                ]
                 |> Query.find
                     [ tag "button"
                     , hasChildWith [ text "click me" ]
                     ]
-                |> Query.has [ class "super-button" ]
+                |> Event.simulate Event.click
+                |> Event.expect ClickedMsg
 
 -}
 hasChildWith : List Selector -> Selector

--- a/src/Test/Html/Selector.elm
+++ b/src/Test/Html/Selector.elm
@@ -13,6 +13,7 @@ module Test.Html.Selector
         , style
         , tag
         , text
+        , havingChild
         )
 
 {-| Selecting HTML elements.
@@ -263,6 +264,31 @@ attribute with the given value.
 text : String -> Selector
 text =
     Internal.Text
+
+
+{-| Matches elements that contain children that match the given selectors.
+
+    import Html
+    import Html.Attributes as Attr
+    import Test exposing (test)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (class, tag, havingChild)
+
+    test : Test
+    test =
+        test "havingChild" <|
+            Html.div []
+                [ Html.button [ Attr.class "super-button" ] [ Html.text "click me" ] ]
+                |> Query.find
+                    [ tag "button"
+                    , havingChild [ text "click me" ]
+                    ]
+                |> Query.has [ class "super-button" ]
+
+-}
+havingChild : List Selector -> Selector
+havingChild =
+    Internal.HavingChild
 
 
 {-| Matches elements that have a

--- a/src/Test/Html/Selector.elm
+++ b/src/Test/Html/Selector.elm
@@ -8,12 +8,12 @@ module Test.Html.Selector
         , classes
         , disabled
         , exactClassName
+        , hasChildWith
         , id
         , selected
         , style
         , tag
         , text
-        , havingChild
         )
 
 {-| Selecting HTML elements.
@@ -272,23 +272,23 @@ text =
     import Html.Attributes as Attr
     import Test exposing (test)
     import Test.Html.Query as Query
-    import Test.Html.Selector exposing (class, tag, havingChild)
+    import Test.Html.Selector exposing (class, hasChildWith, tag)
 
     test : Test
     test =
-        test "havingChild" <|
+        test "..." <|
             Html.div []
                 [ Html.button [ Attr.class "super-button" ] [ Html.text "click me" ] ]
                 |> Query.find
                     [ tag "button"
-                    , havingChild [ text "click me" ]
+                    , hasChildWith [ text "click me" ]
                     ]
                 |> Query.has [ class "super-button" ]
 
 -}
-havingChild : List Selector -> Selector
-havingChild =
-    Internal.HavingChild
+hasChildWith : List Selector -> Selector
+hasChildWith =
+    Internal.HasChildWith
 
 
 {-| Matches elements that have a

--- a/src/Test/Html/Selector/Internal.elm
+++ b/src/Test/Html/Selector/Internal.elm
@@ -13,6 +13,7 @@ type Selector
     | Style (List ( String, String ))
     | Tag String
     | Text String
+    | HavingChild (List Selector)
     | Invalid
 
 
@@ -50,6 +51,12 @@ selectorToString criteria =
 
         Text text ->
             "text " ++ toString text
+
+        HavingChild list ->
+            list
+                |> List.map selectorToString
+                |> String.join " "
+                |> (++) "with children "
 
         Invalid ->
             "invalid"
@@ -115,6 +122,18 @@ query fn fnAll selector list =
 
         Text text ->
             List.concatMap (fn (ElmHtml.Query.ContainsText text)) list
+
+        HavingChild selectors ->
+            List.concatMap
+                (\item ->
+                    case query fn fnAll (All selectors) <| ElmHtml.Query.getChildren item of
+                        [] ->
+                            []
+
+                        _ ->
+                            [ item ]
+                )
+                list
 
         Invalid ->
             []

--- a/src/Test/Html/Selector/Internal.elm
+++ b/src/Test/Html/Selector/Internal.elm
@@ -13,7 +13,7 @@ type Selector
     | Style (List ( String, String ))
     | Tag String
     | Text String
-    | HavingChild (List Selector)
+    | HasChildWith (List Selector)
     | Invalid
 
 
@@ -52,7 +52,7 @@ selectorToString criteria =
         Text text ->
             "text " ++ toString text
 
-        HavingChild list ->
+        HasChildWith list ->
             list
                 |> List.map selectorToString
                 |> String.join " "
@@ -123,7 +123,7 @@ query fn fnAll selector list =
         Text text ->
             List.concatMap (fn (ElmHtml.Query.ContainsText text)) list
 
-        HavingChild selectors ->
+        HasChildWith selectors ->
             List.concatMap
                 (\item ->
                     case query fn fnAll (All selectors) <| ElmHtml.Query.getChildren item of

--- a/tests/Queries.elm
+++ b/tests/Queries.elm
@@ -30,7 +30,7 @@ testers =
     , testFirst
     , testIndex
     , testChildren
-    , testHavingChild
+    , testHasChildWith
     ]
 
 
@@ -253,14 +253,14 @@ testChildren output =
         ]
 
 
-testHavingChild : Single msg -> Test
-testHavingChild output =
-    test "Selector.havingChild" <|
+testHasChildWith : Single msg -> Test
+testHasChildWith output =
+    test "Selector.hasChildWith" <|
         \() ->
             output
                 |> Query.findAll
                     [ tag "button"
-                    , havingChild [ text "click me" ]
+                    , hasChildWith [ text "click me" ]
                     ]
                 |> Expect.all
                     [ Query.count (Expect.equal 1)

--- a/tests/Queries.elm
+++ b/tests/Queries.elm
@@ -30,6 +30,7 @@ testers =
     , testFirst
     , testIndex
     , testChildren
+    , testHavingChild
     ]
 
 
@@ -252,6 +253,21 @@ testChildren output =
         ]
 
 
+testHavingChild : Single msg -> Test
+testHavingChild output =
+    test "Selector.havingChild" <|
+        \() ->
+            output
+                |> Query.findAll
+                    [ tag "button"
+                    , havingChild [ text "click me" ]
+                    ]
+                |> Expect.all
+                    [ Query.count (Expect.equal 1)
+                    , Query.first >> Query.has [ class "super-button" ]
+                    ]
+
+
 sampleHtml : Html msg
 sampleHtml =
     section [ Attr.class "root", Attr.style [ ( "color", "red" ), ( "background", "purple" ), ( "font-weight", "bold" ) ] ]
@@ -273,6 +289,8 @@ sampleHtml =
                 ]
             , section []
                 [ div [ Attr.class "nested-div" ] [ Html.text "boring section" ]
+                , Html.button [ Attr.class "super-button" ] [ Html.text "click me" ]
+                , Html.button [ Attr.class "other-button" ] [ Html.text "the other button" ]
                 , span [ Attr.class "tooltip-questions" ] [ Html.text "?" ]
                 ]
             , footer []
@@ -305,6 +323,8 @@ sampleLazyHtml =
             , section []
                 [ div [ Attr.class "nested-div" ]
                     [ Html.text "boring section"
+                    , Lazy.lazy (\str -> Html.button [ Attr.class "super-button" ] [ Html.text str ]) "click me"
+                    , Lazy.lazy (\str -> Html.button [ Attr.class "other-button" ] [ Html.text str ]) "the other button"
                     , Lazy.lazy (\str -> span [ Attr.class "tooltip-questions" ] [ Html.text str ]) "?"
                     ]
                 ]


### PR DESCRIPTION
> a way to find an element that contains particular text. currently, this gives no result: Query.find [ tag "button", text "Click Me" ] (I believe this happens because the text node that matches the text selector is not itself a button tag? So maybe this could be solved by adding a Selector.havingChild : List Selector -> Selector?) (#32)

this adds `havingChild`.