### PR TITLE
Add link to elm-explorations/test for use in 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # elm-html-test
 
+The contents of this package have been moved to [elm-explorations/test](https://github.com/elm-explorations/test) in Elm 0.19.
+
 Test views by writing expectations about `Html` values. [![Build Status](https://travis-ci.org/eeue56/elm-html-test.svg?branch=master)](https://travis-ci.org/eeue56/elm-html-test)
 
 ```elm


### PR DESCRIPTION
This package has been moved to elm-explorations/test in Elm 0.19, and it would be useful if this was easily discoverable.